### PR TITLE
Create the concept of a Payee to whom fees are paid when captchas solutions are approved or disapproved

### DIFF
--- a/contracts/lib.rs
+++ b/contracts/lib.rs
@@ -1025,7 +1025,7 @@ mod prosopo {
 
         /// Returns the account balance for the specified `dapp`.
         ///
-        /// Returns `0` if the account is non-existent.
+        /// Returns `0` if the account does not exist.
         #[ink(message)]
         pub fn get_dapp_balance(&self, dapp: AccountId) -> Balance {
             return match self.get_dapp_details(dapp) {
@@ -1036,7 +1036,7 @@ mod prosopo {
 
         /// Returns the account balance for the specified `provider`.
         ///
-        /// Returns `0` if the account is non-existent.
+        /// Returns `0` if the account does not exist.
         #[ink(message)]
         pub fn get_provider_balance(&self, provider: AccountId) -> Balance {
             return match self.get_provider_details(provider) {


### PR DESCRIPTION
After a Dapp User has submitted a captcha solution commitment it must be reviewed by a Provider. The Provider does this locally and then approves or disapproves the solution commitment on-chain. At this point, the fee is paid to the Payee. The Payee exists as an enum on the Provider struct.

```
    pub struct Provider {
        status: Status,
        balance: Balance,
        fee: u32,
        payee: Payee,
        service_origin: Hash,
        captcha_dataset_id: Hash,
    }
```

```
    pub enum Payee {
        Provider,
        Dapp,
        None,
    }
```
This allows for fees to be paid to Dapp Operators, received from Dapp Operators, and zero fees.

Also included in this pull request:
- renaming of "Captcha Provider" to "Provider" for ease of reading
- changing the name of balance/stake on Provider and Dapp to be balance in both cases
- balance getter functions for Provider and Dapps, returning zero if they do not exist
- updated approve/disapprove tests to check that fees are correctly transferred