### PR TITLE
Fix contract deploy arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ cargo +nightly tarpaulin --no-default-features --features std --verbose -- --noc
 The contract can be deployed from the command line using `cargo-contract`:
 
 ```bash
-cargo contract instantiate $WASM --args "$ARGS_OWNER $ARGS_PROVIDER_STAKE_DEFAULT" --constructor $CONSTRUCTOR --suri $SURI --value $ENDOWMENT --url '$ENDPOINT:$PORT'
+cargo contract instantiate $WASM --args "$ARGS_OWNER $ARGS_PROVIDER_STAKE_DEFAULT" --constructor $CONSTRUCTOR --suri $SURI --value $ENDOWMENT --url $ENDPOINT:$PORT
 ```
 
 Example values for the variables are given below


### PR DESCRIPTION
With quotes:

```bash
$ cargo contract instantiate $WASM --args "$ARGS_OWNER $ARGS_PROVIDER_STAKE_DEFAULT" --constructor $CONSTRUCTOR --suri $SURI --value $ENDOWMENT --url '$ENDPOINT:$PORT'error: Invalid value "$ENDPOINT:$PORT" for '--url <url>': relative URL without a base

For more information try --help
```

Output test:

```bash
$ echo '$ENDPOINT:$PORT' // $ENDPOINT:$PORT
$ echo $ENDPOINT:$PORT // ws://127.0.0.1:9944
```

Without quotes:

```bash
$ cargo contract instantiate $WASM --args "$ARGS_OWNER $ARGS_PROVIDER_STAKE_DEFAULT" --constructor $CONSTRUCTOR --suri $SURI --value $ENDOWMENT --url $ENDPOINT:$PORT
2022-09-06T14:26:36.476306Z  INFO cargo_contract::crate_metadata: Fetching cargo metadata for Cargo.toml
2022-09-06T14:26:36.529997Z  INFO cargo_contract::cmd::extrinsics::instantiate: Contract code path: ./target/ink/prosopo.wasm
2022-09-06T14:26:36.531940Z  INFO jsonrpsee_client_transport::ws: Connection established to target: Target { sockaddrs: [], host: "127.0.0.1", host_header: "127.0.0.1:9944", _mode: Plain, path_and_query: "/" }
 Dry-running default (skip with --skip-dry-run)
2022-09-06T14:26:36.534109Z  INFO jsonrpsee_client_transport::ws: Connection established to target: Target { sockaddrs: [], host: "127.0.0.1", host_header: "127.0.0.1:9944", _mode: Plain, path_and_query: "/" }
          Result ModuleError: Contracts::ContractTrapped: ["Contract trapped during execution."]
    Gas Consumed 304986078
    Gas Required 304986078
 Storage Deposit StorageDeposit::Charge(1179550000000)
   Debug Message panicked at 'dispatching ink! constructor failed: could not read input', /home/xxx/repos/integration/protocol/contracts/lib.rs:264:5
2022-09-06T14:26:36.542101Z  WARN jsonrpsee_core::client::async_client: Custom("[backend]: frontend dropped; terminate client")
2022-09-06T14:26:36.542193Z  WARN jsonrpsee_core::client::async_client: Custom("[backend]: frontend dropped; terminate client")
ERROR: Pre-submission dry-run failed. Use --skip-dry-run to skip this step.
```

Regarding the error, I'm not sure if there's a problem with the command or with my env vars:

```bash
$ echo $ENDPOINT // ws://127.0.0.1
$ echo $PORT // 9944
$ echo $SURI // //Alice
$ echo $WASM // ./target/ink/prosopo.wasm
$ ll ./target/ink/prosopo.wasm // -rw-rw-r-- 1 xxx xxx 83779 Sep  6 16:09 ./target/ink/prosopo.wasm
$ echo $ARGS_OWNER // 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
$ echo $ARGS_PROVIDER_STAKE_DEFAULT // 2000000000000
$ echo $ENDOWMENT // 1000000000000
```