### PR TITLE
Fix/ink v4 package

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Chris Taylor chris@prosopo.io, George Oastler george@prosopo.io, Vin
 edition = "2021"
 
 [dependencies]
-ink = { version = "4.0.0-beta", default-features = false }
+ink = { git = "https://github.com/paritytech/ink", rev="4655a8b4413cb50cbc38d1b7c173ad426ab06cde", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 rand_chacha = { version = "0.3.1", default-features = false }

--- a/contracts/lib.rs
+++ b/contracts/lib.rs
@@ -1406,7 +1406,7 @@ pub mod prosopo {
         #[should_panic]
         fn test_get_random_number_zero_len() {
             let operator_account = AccountId::from([0x1; 32]);
-            let contract = Prosopo::default(operator_account, PROVIDER_STAKE_DEFAULT);
+            let contract = Prosopo::default(operator_account, STAKE_DEFAULT, STAKE_DEFAULT);
             contract.get_random_number(0, operator_account);
         }
 
@@ -1414,7 +1414,7 @@ pub mod prosopo {
         #[ink::test]
         fn test_get_random_number() {
             let operator_account = AccountId::from([0x1; 32]);
-            let contract = Prosopo::default(operator_account, PROVIDER_STAKE_DEFAULT);
+            let contract = Prosopo::default(operator_account, STAKE_DEFAULT, STAKE_DEFAULT);
             const len: usize = 10;
             let mut number: u64;
             let mut arr = [0; len];


### PR DESCRIPTION
Fixes the ink v4 version to a github commit hash rather than using the latest v4 package found by cargo, as this has a bug with number of generic arguments:
```
Compiling ink v4.0.0-beta
error[E0107]: this struct takes 5 generic arguments but 4 generic arguments were supplied
   --> /home/geopro/.cargo/registry/src/github.com-1ecc6299db9ec823/ink-4.0.0-beta/src/env_access.rs:474:18
    |
474 |         params: &CreateParams<E, Args, Salt, C>,
    |                  ^^^^^^^^^^^^ -  ----  ----  - supplied 4 generic arguments
    |                  |
    |                  expected 5 generic arguments
    |
note: struct defined here, with 5 generic parameters: `E`, `ContractRef`, `Args`, `Salt`, `R`
   --> /home/geopro/.cargo/registry/src/github.com-1ecc6299db9ec823/ink_env-4.0.0-beta.1/src/call/create_builder.rs:166:12
    |
166 | pub struct CreateParams<E, ContractRef, Args, Salt, R>
    |            ^^^^^^^^^^^^ -  -----------  ----  ----  -
help: add missing generic argument
    |
474 |         params: &CreateParams<E, Args, Salt, C, R>,
    |                                               +++

For more information about this error, try `rustc --explain E0107`.
error: could not compile `ink` due to previous error
ERROR: `"/home/geopro/.rustup/toolchains/nightly-2022-08-15-x86_64-unknown-linux-gnu/bin/cargo" "build" "--target=wasm32-unknown-unknown" "-Zbuild-std" "--no-default-features" "--release" "--target-dir=/home/geopro/bench/protocol/contracts/target/ink" "--features" "ink/ink-debug"` failed with exit code: Some(101)
```