### PR TITLE
Cli pass through parameters

### DIFF
--- a/dev/src/cli.ts
+++ b/dev/src/cli.ts
@@ -174,6 +174,27 @@ export async function processArgs(args: string[]) {
     await yargs
         .usage('Usage: $0 [global options] <command> [options]')
         .command(
+            'metadata',
+            'Build the metadata',
+            (yargs) => {
+                return yargs.option('package', {
+                    type: 'string',
+                    demand: true,
+                    desc: 'Target a specific package',
+                    choices: contracts,
+                })
+            },
+            async (argv) => {
+                const [, ...cmdArgsArray] = argv._ // strip the command name
+                let cmdArgs = cmdArgsArray.join(' ')
+
+                const contract = argv.package;
+
+                await exec(`cd ${repoDir} && cargo metadata --manifest-path ${contractsDir}/${contract}/Cargo.toml ${cmdArgs}`)
+            },
+            []
+        )
+        .command(
             'instantiate',
             'Instantiate the contract',
             (yargs) => {

--- a/dev/src/cli.ts
+++ b/dev/src/cli.ts
@@ -130,7 +130,7 @@ export async function processArgs(args: string[]) {
     }
 
     const execCargo = async (argv: yargs.Arguments<{}>, cmd: string, dir?: string) => {
-        const rest = argv._.slice(1); // remove the first arg (the command) to get the rest of the args
+        const rest = argv._.slice(1).join(' '); // remove the first arg (the command) to get the rest of the args
         const toolchain = argv.toolchain ? `+${argv.toolchain}` : ''
         const relDir = path.relative(repoDir, dir || "..")
 

--- a/dev/src/cli.ts
+++ b/dev/src/cli.ts
@@ -178,12 +178,11 @@ export async function processArgs(args: string[]) {
             'expand',
             'Expand the contract (processing all macros, etc)',
             (yargs) => {
-                return yargs.option('package', {
-                    type: 'string',
-                    demand: true,
-                    desc: 'Target a specific package',
-                    choices: contracts,
-                })
+                // cannot build crates
+                yargs = addPackageOption(yargs, contracts)
+                yargs = addToolchainOption(yargs)
+                yargs = addDockerOption(yargs)
+                return yargs
             },
             async (argv) => {
                 const rest = argv._.slice(1); // remove the first arg (the command) to get the rest of the args
@@ -196,12 +195,11 @@ export async function processArgs(args: string[]) {
             'metadata',
             'Build the metadata',
             (yargs) => {
-                return yargs.option('package', {
-                    type: 'string',
-                    demand: true,
-                    desc: 'Target a specific package',
-                    choices: contracts,
-                })
+                // cannot build crates
+                yargs = addPackageOption(yargs, contracts)
+                yargs = addToolchainOption(yargs)
+                yargs = addDockerOption(yargs)
+                return yargs
             },
             async (argv) => {
                 const rest = argv._.slice(1); // remove the first arg (the command) to get the rest of the args
@@ -214,12 +212,11 @@ export async function processArgs(args: string[]) {
             'instantiate',
             'Instantiate the contract',
             (yargs) => {
-                return yargs.option('package', {
-                    type: 'string',
-                    demand: true,
-                    desc: 'Target a specific package',
-                    choices: contracts,
-                })
+                // cannot build crates
+                yargs = addPackageOption(yargs, contracts)
+                yargs = addToolchainOption(yargs)
+                yargs = addDockerOption(yargs)
+                return yargs
             },
             async (argv) => {
                 const rest = argv._.slice(1); // remove the first arg (the command) to get the rest of the args
@@ -235,7 +232,6 @@ export async function processArgs(args: string[]) {
                 // cannot build crates
                 yargs = addPackageOption(yargs, contracts)
                 yargs = addToolchainOption(yargs)
-                yargs = addReleaseOption(yargs)
                 yargs = addDockerOption(yargs)
                 return yargs
             },
@@ -251,7 +247,6 @@ export async function processArgs(args: string[]) {
             'test',
             'Test the crates and contracts',
             (yargs) => {
-                yargs = addPackageOption(yargs)
                 yargs = addToolchainOption(yargs)
                 yargs = addDockerOption(yargs)
                 return yargs
@@ -264,7 +259,6 @@ export async function processArgs(args: string[]) {
             'fmt',
             'Format the crates and contracts',
             (yargs) => {
-                yargs = addPackageOption(yargs)
                 yargs = addToolchainOption(yargs)
                 yargs = addDockerOption(yargs)
                 yargs = yargs.option('check', {
@@ -290,9 +284,7 @@ export async function processArgs(args: string[]) {
             'clippy',
             'Clippy the crates and contracts',
             (yargs) => {
-                yargs = addPackageOption(yargs)
                 yargs = addToolchainOption(yargs)
-                yargs = addFixOption(yargs)
                 yargs = addDockerOption(yargs)
                 return yargs
             },


### PR DESCRIPTION
Enable passing through any commands to sub-commands of the cli. E.g. passing parameters through to cargo currently requires you to replicate the parameter in yargs and pass it through. Instead (this way), any unrecognised parameters get passed straight through yargs and directly to cargo