### PR TITLE
remove tests_inner wrapper, no longer needed

### DIFF
--- a/contracts/captcha/src/lib.rs
+++ b/contracts/captcha/src/lib.rs
@@ -1540,219 +1540,186 @@ pub mod prosopo {
         const CONTRACT_ACCOUNT_PREFIX: u8 = 0x05;
         const CODE_HASH_PREFIX: u8 = 0x06;
 
-        mod tests_inner {
+        /// Imports all the definitions from the outer scope so we can use them here.
+        use super::*;
 
-            /// Imports all the definitions from the outer scope so we can use them here.
-            use super::*;
+        // unused account is 0x00 - do not use this, it will be the default caller, so could get around caller checks accidentally
+        fn get_unused_account() -> AccountId {
+            AccountId::from([0x00; 32])
+        }
 
-            // unused account is 0x00 - do not use this, it will be the default caller, so could get around caller checks accidentally
-            fn get_unused_account() -> AccountId {
-                AccountId::from([0x00; 32])
-            }
+        // build an account. Accounts have the first byte set to the type of account and the next 16 bytes are the index of the account
+        fn get_account_bytes(account_type: u8, index: u128) -> [u8; 32] {
+            let mut bytes = [0x00; 32];
+            bytes[0] = account_type;
+            bytes[1..17].copy_from_slice(&index.to_le_bytes());
+            bytes
+        }
 
-            // build an account. Accounts have the first byte set to the type of account and the next 16 bytes are the index of the account
-            fn get_account_bytes(account_type: u8, index: u128) -> [u8; 32] {
-                let mut bytes = [0x00; 32];
-                bytes[0] = account_type;
-                bytes[1..17].copy_from_slice(&index.to_le_bytes());
-                bytes
-            }
-
-            fn get_account(account_type: u8, index: u128) -> AccountId {
-                let account = AccountId::from(get_account_bytes(account_type, index));
-                // fund the account so it exists if not already
-                let balance = get_account_balance(account);
-                if balance.is_err() {
-                    // account doesn't have the existential deposit so doesn't exist
-                    // give it funds to create it
-                    set_account_balance(account, 1);
-                }
-                account
-            }
-
-            /// get the nth admin account. This ensures against account collisions, e.g. 1 account being both a provider and an admin, which can obviously cause issues with caller guards / permissions in the contract.
-            fn get_admin_account(index: u128) -> AccountId {
-                get_account(ADMIN_ACCOUNT_PREFIX, index)
-            }
-
-            /// get the nth provider account. This ensures against account collisions, e.g. 1 account being both a provider and an admin, which can obviously cause issues with caller guards / permissions in the contract.
-            fn get_provider_account(index: u128) -> AccountId {
-                get_account(PROVIDER_ACCOUNT_PREFIX, index)
-            }
-
-            /// get the nth dapp account. This ensures against account collisions, e.g. 1 account being both a provider and an admin, which can obviously cause issues with caller guards / permissions in the contract.
-            fn get_dapp_account(index: u128) -> AccountId {
-                get_account(DAPP_ACCOUNT_PREFIX, index)
-            }
-
-            /// get the nth user account. This ensures against account collisions, e.g. 1 account being both a provider and an admin, which can obviously cause issues with caller guards / permissions in the contract.
-            fn get_user_account(index: u128) -> AccountId {
-                get_account(USER_ACCOUNT_PREFIX, index)
-            }
-
-            /// get the nth contract account. This ensures against account collisions, e.g. 1 account being both a provider and an admin, which can obviously cause issues with caller guards / permissions in the contract.
-            fn get_contract_account(index: u128) -> AccountId {
-                get_account(CONTRACT_ACCOUNT_PREFIX, index)
-            }
-
-            /// get the nth code hash. This ensures against account collisions, e.g. 1 account being both a provider and an admin, which can obviously cause issues with caller guards / permissions in the contract.
-            fn get_code_hash(index: u128) -> [u8; 32] {
-                get_account_bytes(CODE_HASH_PREFIX, index)
-            }
-
-            /// get the nth contract. This ensures against account collisions, e.g. 1 account being both a provider and an admin, which can obviously cause issues with caller guards / permissions in the contract.
-            fn get_contract(index: u128) -> Prosopo {
-                let account = get_account(CONTRACT_ACCOUNT_PREFIX, index); // the account for the contract
-                                                                           // make sure the contract gets allocated the above account
-                set_callee(account);
-                // give the contract account some funds
+        fn get_account(account_type: u8, index: u128) -> AccountId {
+            let account = AccountId::from(get_account_bytes(account_type, index));
+            // fund the account so it exists if not already
+            let balance = get_account_balance(account);
+            if balance.is_err() {
+                // account doesn't have the existential deposit so doesn't exist
+                // give it funds to create it
                 set_account_balance(account, 1);
-                // set the caller to the first admin
-                set_caller(get_admin_account(0));
-                // now construct the contract instance
-                let mut contract =
-                    Prosopo::new_unguarded(STAKE_THRESHOLD, STAKE_THRESHOLD, 10, 1000000, 0, 1000);
-                // set the caller back to the unused acc
-                set_caller(get_unused_account());
-                // check the contract was created with the correct account
-                assert_eq!(contract.env().account_id(), account);
-                contract
             }
+            account
+        }
 
-            #[ink::test]
-            fn test_ctor_guard_pass() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
+        /// get the nth admin account. This ensures against account collisions, e.g. 1 account being both a provider and an admin, which can obviously cause issues with caller guards / permissions in the contract.
+        fn get_admin_account(index: u128) -> AccountId {
+            get_account(ADMIN_ACCOUNT_PREFIX, index)
+        }
 
-                // only able to instantiate from the alice account
-                set_caller(AccountId::from([
-                    212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130,
-                    44, 133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125,
-                ]));
-                let contract = Prosopo::new(STAKE_THRESHOLD, STAKE_THRESHOLD, 10, 1000000, 0, 1000);
-                // should construct successfully
-            }
+        /// get the nth provider account. This ensures against account collisions, e.g. 1 account being both a provider and an admin, which can obviously cause issues with caller guards / permissions in the contract.
+        fn get_provider_account(index: u128) -> AccountId {
+            get_account(PROVIDER_ACCOUNT_PREFIX, index)
+        }
 
-            #[ink::test]
-            #[should_panic]
-            fn test_ctor_guard_fail() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
+        /// get the nth dapp account. This ensures against account collisions, e.g. 1 account being both a provider and an admin, which can obviously cause issues with caller guards / permissions in the contract.
+        fn get_dapp_account(index: u128) -> AccountId {
+            get_account(DAPP_ACCOUNT_PREFIX, index)
+        }
 
-                // only able to instantiate from the alice account
-                set_caller(default_accounts().bob);
-                let contract = Prosopo::new(STAKE_THRESHOLD, STAKE_THRESHOLD, 10, 1000000, 0, 1000);
-                // should fail to construct and panic
-            }
+        /// get the nth user account. This ensures against account collisions, e.g. 1 account being both a provider and an admin, which can obviously cause issues with caller guards / permissions in the contract.
+        fn get_user_account(index: u128) -> AccountId {
+            get_account(USER_ACCOUNT_PREFIX, index)
+        }
 
-            #[ink::test]
-            fn test_ctor() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
+        /// get the nth contract account. This ensures against account collisions, e.g. 1 account being both a provider and an admin, which can obviously cause issues with caller guards / permissions in the contract.
+        fn get_contract_account(index: u128) -> AccountId {
+            get_account(CONTRACT_ACCOUNT_PREFIX, index)
+        }
 
-                let mut contract = get_contract(0);
+        /// get the nth code hash. This ensures against account collisions, e.g. 1 account being both a provider and an admin, which can obviously cause issues with caller guards / permissions in the contract.
+        fn get_code_hash(index: u128) -> [u8; 32] {
+            get_account_bytes(CODE_HASH_PREFIX, index)
+        }
 
-                // ctor params should be set
-                assert_eq!(contract.provider_stake_threshold, STAKE_THRESHOLD);
-                assert_eq!(contract.dapp_stake_threshold, STAKE_THRESHOLD);
-                assert_eq!(contract.admin, get_admin_account(0));
-                assert_eq!(contract.max_user_history_len, 10);
-                assert_eq!(contract.max_user_history_age, 1000000);
-                assert_eq!(contract.min_num_active_providers, 0);
-                assert_eq!(contract.max_provider_fee, 1000);
+        /// get the nth contract. This ensures against account collisions, e.g. 1 account being both a provider and an admin, which can obviously cause issues with caller guards / permissions in the contract.
+        fn get_contract(index: u128) -> Prosopo {
+            let account = get_account(CONTRACT_ACCOUNT_PREFIX, index); // the account for the contract
+                                                                       // make sure the contract gets allocated the above account
+            set_callee(account);
+            // give the contract account some funds
+            set_account_balance(account, 1);
+            // set the caller to the first admin
+            set_caller(get_admin_account(0));
+            // now construct the contract instance
+            let mut contract =
+                Prosopo::new_unguarded(STAKE_THRESHOLD, STAKE_THRESHOLD, 10, 1000000, 0, 1000);
+            // set the caller back to the unused acc
+            set_caller(get_unused_account());
+            // check the contract was created with the correct account
+            assert_eq!(contract.env().account_id(), account);
+            contract
+        }
 
-                // default state should be set
-                for payee in contract.get_payees().iter() {
-                    for status in contract.get_statuses().iter() {
-                        assert_eq!(
-                            contract.provider_accounts.get(ProviderState {
-                                payee: *payee,
-                                status: *status
-                            }),
-                            None
-                        );
-                    }
+        #[ink::test]
+        fn test_ctor_guard_pass() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            // only able to instantiate from the alice account
+            set_caller(AccountId::from([
+                212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130, 44,
+                133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125,
+            ]));
+            let contract = Prosopo::new(STAKE_THRESHOLD, STAKE_THRESHOLD, 10, 1000000, 0, 1000);
+            // should construct successfully
+        }
+
+        #[ink::test]
+        #[should_panic]
+        fn test_ctor_guard_fail() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            // only able to instantiate from the alice account
+            set_caller(default_accounts().bob);
+            let contract = Prosopo::new(STAKE_THRESHOLD, STAKE_THRESHOLD, 10, 1000000, 0, 1000);
+            // should fail to construct and panic
+        }
+
+        #[ink::test]
+        fn test_ctor() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+
+            // ctor params should be set
+            assert_eq!(contract.provider_stake_threshold, STAKE_THRESHOLD);
+            assert_eq!(contract.dapp_stake_threshold, STAKE_THRESHOLD);
+            assert_eq!(contract.admin, get_admin_account(0));
+            assert_eq!(contract.max_user_history_len, 10);
+            assert_eq!(contract.max_user_history_age, 1000000);
+            assert_eq!(contract.min_num_active_providers, 0);
+            assert_eq!(contract.max_provider_fee, 1000);
+
+            // default state should be set
+            for payee in contract.get_payees().iter() {
+                for status in contract.get_statuses().iter() {
+                    assert_eq!(
+                        contract.provider_accounts.get(ProviderState {
+                            payee: *payee,
+                            status: *status
+                        }),
+                        None
+                    );
                 }
-                assert_eq!(contract.dapp_accounts.get(), None);
-                assert_eq!(contract.user_accounts.get(), None);
             }
+            assert_eq!(contract.dapp_accounts.get(), None);
+            assert_eq!(contract.user_accounts.get(), None);
+        }
 
-            /// Test accounts are funded with existential deposit
-            #[ink::test]
-            fn test_accounts_funded() {
-                for func in vec![
-                    get_admin_account,
-                    get_provider_account,
-                    get_dapp_account,
-                    get_user_account,
-                    get_contract_account,
-                ]
-                .iter()
-                {
-                    for i in 0..10 {
-                        let account = func(i);
-                        // check the account has funds. Will panic if not as no existential deposit == account not found
-                        get_account_balance(account).unwrap();
-                    }
-                }
-
-                // same for contracts
+        /// Test accounts are funded with existential deposit
+        #[ink::test]
+        fn test_accounts_funded() {
+            for func in vec![
+                get_admin_account,
+                get_provider_account,
+                get_dapp_account,
+                get_user_account,
+                get_contract_account,
+            ]
+            .iter()
+            {
                 for i in 0..10 {
-                    let contract = get_contract(i);
+                    let account = func(i);
                     // check the account has funds. Will panic if not as no existential deposit == account not found
-                    get_account_balance(contract.env().account_id()).unwrap();
+                    get_account_balance(account).unwrap();
                 }
             }
 
-            /// Are the unit test accounts unique, i.e. make sure there's no collisions in accounts destined for different roles, as this would invalidate any caller guards
-            #[ink::test]
-            fn test_accounts_unique() {
-                let mut set: std::collections::HashSet<[u8; 32]> = std::collections::HashSet::new();
-
-                // for each method of generating an account
-                for func in vec![
-                    get_admin_account,
-                    get_provider_account,
-                    get_dapp_account,
-                    get_user_account,
-                    get_contract_account,
-                ]
-                .iter()
-                {
-                    // try the first 10 accounts
-                    for i in 0..10 {
-                        let account = func(i);
-                        assert!(
-                            set.insert(*AsRef::<[u8; 32]>::as_ref(&account)),
-                            "Duplicate account ID found: {:?}",
-                            account
-                        );
-                    }
-                }
-
-                // do the same for non-account based IDs
-                for func in vec![get_code_hash].iter() {
-                    // try the first 10 accounts
-                    for i in 0..10 {
-                        let account = func(i);
-                        assert!(
-                            set.insert(account),
-                            "Duplicate account ID found: {:?}",
-                            account
-                        );
-                    }
-                }
+            // same for contracts
+            for i in 0..10 {
+                let contract = get_contract(i);
+                // check the account has funds. Will panic if not as no existential deposit == account not found
+                get_account_balance(contract.env().account_id()).unwrap();
             }
+        }
 
-            /// Are the unit test contracts unique, i.e. make sure there's no collisions in contract accounts as two contracts with the same account could work around funding tests as utilising the same account
-            #[ink::test]
-            fn test_contracts_unique() {
-                let mut set: std::collections::HashSet<[u8; 32]> = std::collections::HashSet::new();
+        /// Are the unit test accounts unique, i.e. make sure there's no collisions in accounts destined for different roles, as this would invalidate any caller guards
+        #[ink::test]
+        fn test_accounts_unique() {
+            let mut set: std::collections::HashSet<[u8; 32]> = std::collections::HashSet::new();
 
-                // for the first 10 contracts
-                for i in 0..9 {
-                    let contract = get_contract(i);
-                    let account = contract.env().account_id();
+            // for each method of generating an account
+            for func in vec![
+                get_admin_account,
+                get_provider_account,
+                get_dapp_account,
+                get_user_account,
+                get_contract_account,
+            ]
+            .iter()
+            {
+                // try the first 10 accounts
+                for i in 0..10 {
+                    let account = func(i);
                     assert!(
                         set.insert(*AsRef::<[u8; 32]>::as_ref(&account)),
                         "Duplicate account ID found: {:?}",
@@ -1761,1000 +1728,1171 @@ pub mod prosopo {
                 }
             }
 
-            // #[ink::test]
-            // fn test_set_code_hash() {
-
-            //     // always set the caller to the unused account to start, avoid any mistakes with caller checks
-            //     set_caller(get_unused_account());
-            //
-
-            //     let mut contract = get_contract(0);
-
-            //     let new_code_hash = get_code_hash(1);
-            //     let old_code_hash = contract.env().own_code_hash().unwrap();
-            //     assert_ne!(Hash::from(new_code_hash), old_code_hash);
-
-            //     set_caller(get_admin_account(0)); // an account which does have permission to call set code hash
-
-            //     assert_eq!(contract.set_code_hash(new_code_hash), Ok(()));
-
-            //     assert_eq!(contract.env().own_code_hash().unwrap(), Hash::from(new_code_hash));
-            // }
-
-            #[ink::test]
-            fn test_set_code_hash_unauthorised() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-
-                set_caller(get_user_account(0)); // an account which does not have permission to call set code hash
-
-                let new_code_hash = get_code_hash(1);
-                assert_eq!(
-                    contract.set_code_hash(new_code_hash),
-                    Err(Error::NotAuthorised)
-                );
-            }
-
-            #[ink::test]
-            fn test_terminate() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-                set_caller(get_admin_account(0)); // an account which does have permission to call terminate
-
-                let contract_account = contract.env().account_id();
-                let bal = get_account_balance(contract_account).unwrap();
-                let admin = get_admin_account(0);
-                let should_terminate = move || contract.terminate().unwrap();
-                ink::env::test::assert_contract_termination::<ink::env::DefaultEnvironment, _>(
-                    should_terminate,
-                    get_admin_account(0),
-                    bal,
-                );
-            }
-
-            #[ink::test]
-            fn test_terminate_unauthorised() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-                set_caller(get_user_account(0)); // an account which does not have permission to call terminate
-
-                assert_eq!(contract.terminate().unwrap_err(), Error::NotAuthorised);
-            }
-
-            #[ink::test]
-            fn test_withdraw() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-                println!("contract {:?}", contract.env().account_id());
-
-                // give the contract funds
-                set_account_balance(contract.env().account_id(), 10000000000);
-                set_caller(get_admin_account(0)); // use the admin acc
-                let admin_bal: u128 = get_account_balance(get_admin_account(0)).unwrap();
-                let contract_bal: u128 = get_account_balance(contract.env().account_id()).unwrap();
-                let withdraw_amount: u128 = 1;
-                contract.withdraw(withdraw_amount).unwrap();
-                assert_eq!(
-                    get_account_balance(get_admin_account(0)).unwrap(),
-                    admin_bal + withdraw_amount
-                );
-                assert_eq!(
-                    get_account_balance(contract.env().account_id()).unwrap(),
-                    contract_bal - withdraw_amount
-                );
-            }
-
-            #[ink::test]
-            #[should_panic]
-            fn test_withdraw_insufficient_funds() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-
-                set_caller(get_admin_account(0)); // use the admin acc
-                let admin_bal = get_account_balance(get_admin_account(0)).unwrap();
-                let contract_bal = get_account_balance(contract.env().account_id()).unwrap();
-                contract.withdraw(contract_bal + 1); // panics as bal would go below existential deposit
-            }
-
-            #[ink::test]
-            fn test_withdraw_unauthorised() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-
-                // give the contract funds
-                set_caller(get_user_account(0)); // use the admin acc
-                assert_eq!(contract.withdraw(1), Err(Error::NotAuthorised));
-            }
-
-            #[ink::test]
-            fn test_check_admin() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
+            // do the same for non-account based IDs
+            for func in vec![get_code_hash].iter() {
                 // try the first 10 accounts
-                for i in 0..9 {
-                    let acc = get_admin_account(i);
-                    if acc == contract.admin {
-                        assert!(contract.check_admin(acc).is_ok());
-                        assert!(contract.check_not_admin(acc).is_err());
-                        set_caller(acc);
-                        assert!(contract.check_caller_admin().is_ok());
-                    } else {
-                        assert!(contract.check_admin(acc).is_err());
-                        assert!(contract.check_not_admin(acc).is_ok());
-                        set_caller(acc);
-                        assert!(contract.check_caller_admin().is_err());
-                    }
+                for i in 0..10 {
+                    let account = func(i);
+                    assert!(
+                        set.insert(account),
+                        "Duplicate account ID found: {:?}",
+                        account
+                    );
                 }
             }
+        }
 
-            #[ink::test]
-            fn test_set_admin() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
+        /// Are the unit test contracts unique, i.e. make sure there's no collisions in contract accounts as two contracts with the same account could work around funding tests as utilising the same account
+        #[ink::test]
+        fn test_contracts_unique() {
+            let mut set: std::collections::HashSet<[u8; 32]> = std::collections::HashSet::new();
 
-                let mut contract = get_contract(0);
-                let old_admin = contract.admin;
-                let new_admin = get_admin_account(1);
-                assert_ne!(old_admin, new_admin);
-
-                contract.check_admin(old_admin).unwrap();
-                contract.check_not_admin(new_admin).unwrap();
-
-                set_caller(old_admin);
-                contract.set_admin(new_admin).unwrap();
-
-                contract.check_admin(new_admin).unwrap();
-                contract.check_not_admin(old_admin).unwrap();
-            }
-
-            #[ink::test]
-            fn test_set_admin_unauthorised() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-                let old_admin = contract.admin;
-                let new_admin = get_admin_account(1);
-                assert_ne!(old_admin, new_admin);
-
-                contract.check_admin(old_admin).unwrap();
-                contract.check_not_admin(new_admin).unwrap();
-
-                // can only call set_admin from the current admin account (old admin)
-                set_caller(new_admin);
-                contract.set_admin(new_admin).unwrap_err();
-            }
-
-            #[ink::test]
-            fn test_ctor_caller_admin() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-
-                // check the caller is admin
-                assert_eq!(contract.admin, get_admin_account(0));
-            }
-
-            /// Assert contract provider minimum stake default set from constructor.
-            #[ink::test]
-            pub fn test_provider_stake_threshold() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-
-                let provider_stake_threshold: u128 = contract.get_provider_stake_threshold();
-                assert!(STAKE_THRESHOLD.eq(&provider_stake_threshold));
-            }
-
-            /// Assert contract dapp minimum stake default set from constructor.
-            #[ink::test]
-            pub fn test_dapp_stake_threshold() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-                let dapp_stake_threshold: u128 = contract.get_dapp_stake_threshold();
-                assert!(STAKE_THRESHOLD.eq(&dapp_stake_threshold));
-            }
-
-            /// Test provider register
-            #[ink::test]
-            fn test_provider_register() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-                let provider_account = AccountId::from([0x2; 32]);
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                // give provider some funds, but not enough to be above the minimum stake
-                set_account_balance(provider_account, 1);
-                let url: Vec<u8> = vec![1, 2, 3];
-                let fee: u32 = 100;
-                contract.provider_register(url, fee, Payee::Dapp);
-                assert!(contract.providers.get(provider_account).is_some());
-                println!(
-                    "{}",
-                    contract
-                        .provider_accounts
-                        .get(ProviderState {
-                            status: GovernanceStatus::Inactive,
-                            payee: Payee::Provider
-                        })
-                        .unwrap_or_default()
-                        .contains(&provider_account)
+            // for the first 10 contracts
+            for i in 0..9 {
+                let contract = get_contract(i);
+                let account = contract.env().account_id();
+                assert!(
+                    set.insert(*AsRef::<[u8; 32]>::as_ref(&account)),
+                    "Duplicate account ID found: {:?}",
+                    account
                 );
+            }
+        }
 
-                assert!(contract
+        // #[ink::test]
+        // fn test_set_code_hash() {
+
+        //     // always set the caller to the unused account to start, avoid any mistakes with caller checks
+        //     set_caller(get_unused_account());
+        //
+
+        //     let mut contract = get_contract(0);
+
+        //     let new_code_hash = get_code_hash(1);
+        //     let old_code_hash = contract.env().own_code_hash().unwrap();
+        //     assert_ne!(Hash::from(new_code_hash), old_code_hash);
+
+        //     set_caller(get_admin_account(0)); // an account which does have permission to call set code hash
+
+        //     assert_eq!(contract.set_code_hash(new_code_hash), Ok(()));
+
+        //     assert_eq!(contract.env().own_code_hash().unwrap(), Hash::from(new_code_hash));
+        // }
+
+        #[ink::test]
+        fn test_set_code_hash_unauthorised() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+
+            set_caller(get_user_account(0)); // an account which does not have permission to call set code hash
+
+            let new_code_hash = get_code_hash(1);
+            assert_eq!(
+                contract.set_code_hash(new_code_hash),
+                Err(Error::NotAuthorised)
+            );
+        }
+
+        #[ink::test]
+        fn test_terminate() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+            set_caller(get_admin_account(0)); // an account which does have permission to call terminate
+
+            let contract_account = contract.env().account_id();
+            let bal = get_account_balance(contract_account).unwrap();
+            let admin = get_admin_account(0);
+            let should_terminate = move || contract.terminate().unwrap();
+            ink::env::test::assert_contract_termination::<ink::env::DefaultEnvironment, _>(
+                should_terminate,
+                get_admin_account(0),
+                bal,
+            );
+        }
+
+        #[ink::test]
+        fn test_terminate_unauthorised() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+            set_caller(get_user_account(0)); // an account which does not have permission to call terminate
+
+            assert_eq!(contract.terminate().unwrap_err(), Error::NotAuthorised);
+        }
+
+        #[ink::test]
+        fn test_withdraw() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+            println!("contract {:?}", contract.env().account_id());
+
+            // give the contract funds
+            set_account_balance(contract.env().account_id(), 10000000000);
+            set_caller(get_admin_account(0)); // use the admin acc
+            let admin_bal: u128 = get_account_balance(get_admin_account(0)).unwrap();
+            let contract_bal: u128 = get_account_balance(contract.env().account_id()).unwrap();
+            let withdraw_amount: u128 = 1;
+            contract.withdraw(withdraw_amount).unwrap();
+            assert_eq!(
+                get_account_balance(get_admin_account(0)).unwrap(),
+                admin_bal + withdraw_amount
+            );
+            assert_eq!(
+                get_account_balance(contract.env().account_id()).unwrap(),
+                contract_bal - withdraw_amount
+            );
+        }
+
+        #[ink::test]
+        #[should_panic]
+        fn test_withdraw_insufficient_funds() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+
+            set_caller(get_admin_account(0)); // use the admin acc
+            let admin_bal = get_account_balance(get_admin_account(0)).unwrap();
+            let contract_bal = get_account_balance(contract.env().account_id()).unwrap();
+            contract.withdraw(contract_bal + 1); // panics as bal would go below existential deposit
+        }
+
+        #[ink::test]
+        fn test_withdraw_unauthorised() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+
+            // give the contract funds
+            set_caller(get_user_account(0)); // use the admin acc
+            assert_eq!(contract.withdraw(1), Err(Error::NotAuthorised));
+        }
+
+        #[ink::test]
+        fn test_check_admin() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+            // try the first 10 accounts
+            for i in 0..9 {
+                let acc = get_admin_account(i);
+                if acc == contract.admin {
+                    assert!(contract.check_admin(acc).is_ok());
+                    assert!(contract.check_not_admin(acc).is_err());
+                    set_caller(acc);
+                    assert!(contract.check_caller_admin().is_ok());
+                } else {
+                    assert!(contract.check_admin(acc).is_err());
+                    assert!(contract.check_not_admin(acc).is_ok());
+                    set_caller(acc);
+                    assert!(contract.check_caller_admin().is_err());
+                }
+            }
+        }
+
+        #[ink::test]
+        fn test_set_admin() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+            let old_admin = contract.admin;
+            let new_admin = get_admin_account(1);
+            assert_ne!(old_admin, new_admin);
+
+            contract.check_admin(old_admin).unwrap();
+            contract.check_not_admin(new_admin).unwrap();
+
+            set_caller(old_admin);
+            contract.set_admin(new_admin).unwrap();
+
+            contract.check_admin(new_admin).unwrap();
+            contract.check_not_admin(old_admin).unwrap();
+        }
+
+        #[ink::test]
+        fn test_set_admin_unauthorised() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+            let old_admin = contract.admin;
+            let new_admin = get_admin_account(1);
+            assert_ne!(old_admin, new_admin);
+
+            contract.check_admin(old_admin).unwrap();
+            contract.check_not_admin(new_admin).unwrap();
+
+            // can only call set_admin from the current admin account (old admin)
+            set_caller(new_admin);
+            contract.set_admin(new_admin).unwrap_err();
+        }
+
+        #[ink::test]
+        fn test_ctor_caller_admin() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+
+            // check the caller is admin
+            assert_eq!(contract.admin, get_admin_account(0));
+        }
+
+        /// Assert contract provider minimum stake default set from constructor.
+        #[ink::test]
+        pub fn test_provider_stake_threshold() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+
+            let provider_stake_threshold: u128 = contract.get_provider_stake_threshold();
+            assert!(STAKE_THRESHOLD.eq(&provider_stake_threshold));
+        }
+
+        /// Assert contract dapp minimum stake default set from constructor.
+        #[ink::test]
+        pub fn test_dapp_stake_threshold() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+            let dapp_stake_threshold: u128 = contract.get_dapp_stake_threshold();
+            assert!(STAKE_THRESHOLD.eq(&dapp_stake_threshold));
+        }
+
+        /// Test provider register
+        #[ink::test]
+        fn test_provider_register() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+            let provider_account = AccountId::from([0x2; 32]);
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            // give provider some funds, but not enough to be above the minimum stake
+            set_account_balance(provider_account, 1);
+            let url: Vec<u8> = vec![1, 2, 3];
+            let fee: u32 = 100;
+            contract.provider_register(url, fee, Payee::Dapp);
+            assert!(contract.providers.get(provider_account).is_some());
+            println!(
+                "{}",
+                contract
                     .provider_accounts
                     .get(ProviderState {
                         status: GovernanceStatus::Inactive,
-                        payee: Payee::Dapp
+                        payee: Payee::Provider
                     })
                     .unwrap_or_default()
-                    .contains(&provider_account));
-            }
+                    .contains(&provider_account)
+            );
 
-            /// Test provider deregister
-            #[ink::test]
-            fn test_provider_deactivate() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
+            assert!(contract
+                .provider_accounts
+                .get(ProviderState {
+                    status: GovernanceStatus::Inactive,
+                    payee: Payee::Dapp
+                })
+                .unwrap_or_default()
+                .contains(&provider_account));
+        }
 
-                let mut contract = get_contract(0);
-                let provider_account = AccountId::from([0x2; 32]);
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                let url: Vec<u8> = vec![1, 2, 3];
-                let fee: u32 = 100;
-                contract.provider_register(url, fee, Payee::Dapp);
-                assert!(contract.providers.get(provider_account).is_some());
-                contract.provider_deactivate();
-                let provider_record = contract.providers.get(provider_account).unwrap();
-                assert!(provider_record.status == GovernanceStatus::Inactive);
-            }
+        /// Test provider deregister
+        #[ink::test]
+        fn test_provider_deactivate() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
 
-            /// Test list providers
-            #[ink::test]
-            fn test_list_providers_by_ids() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
+            let mut contract = get_contract(0);
+            let provider_account = AccountId::from([0x2; 32]);
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            let url: Vec<u8> = vec![1, 2, 3];
+            let fee: u32 = 100;
+            contract.provider_register(url, fee, Payee::Dapp);
+            assert!(contract.providers.get(provider_account).is_some());
+            contract.provider_deactivate();
+            let provider_record = contract.providers.get(provider_account).unwrap();
+            assert!(provider_record.status == GovernanceStatus::Inactive);
+        }
 
-                let mut contract = get_contract(0);
-                let provider_account = AccountId::from([0x2; 32]);
-                let url: Vec<u8> = vec![1, 2, 3];
-                let fee: u32 = 100;
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                contract.provider_register(url, fee, Payee::Dapp);
-                let registered_provider_account = contract.providers.get(provider_account);
-                assert!(registered_provider_account.is_some());
-                let returned_list = contract
-                    .list_providers_by_ids(vec![provider_account])
-                    .unwrap();
-                assert!(returned_list == vec![registered_provider_account.unwrap()]);
-            }
+        /// Test list providers
+        #[ink::test]
+        fn test_list_providers_by_ids() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
 
-            // test get random number with zero length, i.e. no range to pick from
-            #[ink::test]
-            #[should_panic]
-            fn test_get_random_number_zero_len() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
+            let mut contract = get_contract(0);
+            let provider_account = AccountId::from([0x2; 32]);
+            let url: Vec<u8> = vec![1, 2, 3];
+            let fee: u32 = 100;
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            contract.provider_register(url, fee, Payee::Dapp);
+            let registered_provider_account = contract.providers.get(provider_account);
+            assert!(registered_provider_account.is_some());
+            let returned_list = contract
+                .list_providers_by_ids(vec![provider_account])
+                .unwrap();
+            assert!(returned_list == vec![registered_provider_account.unwrap()]);
+        }
 
-                let mut contract = get_contract(0);
-                contract.get_random_number(0, get_unused_account(), get_unused_account());
-            }
+        // test get random number with zero length, i.e. no range to pick from
+        #[ink::test]
+        #[should_panic]
+        fn test_get_random_number_zero_len() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
 
-            // Test get random number
-            #[ink::test]
-            fn test_get_random_number() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
+            let mut contract = get_contract(0);
+            contract.get_random_number(0, get_unused_account(), get_unused_account());
+        }
 
-                let mut contract = get_contract(0);
-                let acc1 = AccountId::from([0x1; 32]);
-                let acc2 = AccountId::from([0x2; 32]);
-                const len: usize = 10;
-                let mut arr = [0; len];
-                // get several random numbers, one per block
-                for item in arr.iter_mut().take(len) {
-                    let number = contract.get_random_number(100, acc1, acc2);
-                    *item = number;
-                    println!(
-                        "{:?} {:?} {:?}",
-                        number,
-                        ink::env::block_number::<ink::env::DefaultEnvironment>(),
-                        ink::env::block_timestamp::<ink::env::DefaultEnvironment>()
-                    );
-                    ink::env::test::advance_block::<ink::env::DefaultEnvironment>();
-                }
-                // check that the random numbers match precomputed values
-                assert_eq!(&[29, 95, 86, 92, 88, 24, 59, 73, 96, 53], &arr);
-            }
+        // Test get random number
+        #[ink::test]
+        fn test_get_random_number() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
 
-            /// Helper function for converting string to Hash
-            fn str_to_hash(str: String) -> Hash {
-                let mut result = Hash::default();
-                let len_result = result.as_ref().len();
-                let mut hash_output = <<Blake2x256 as HashOutput>::Type as Default>::default();
-                <Blake2x256 as CryptoHash>::hash(str.as_ref(), &mut hash_output);
-                let copy_len = core::cmp::min(hash_output.len(), len_result);
-                result.as_mut()[0..copy_len].copy_from_slice(&hash_output[0..copy_len]);
-                result
-            }
-
-            /// Provider Register Helper
-            fn generate_provider_data(id: u8, port: &str, fee: u32) -> (AccountId, Vec<u8>, u32) {
-                let provider_account = AccountId::from([id; 32]);
-                let url = port.as_bytes().to_vec();
-
-                (provider_account, url, fee)
-            }
-
-            /// Test provider register and update
-            #[ink::test]
-            fn test_provider_register_and_update() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-                let (provider_account, url, fee) = generate_provider_data(0x2, "2424", 0);
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                contract.provider_register(url, fee, Payee::Dapp).unwrap();
-                assert!(contract.providers.get(provider_account).is_some());
-                assert!(contract
-                    .provider_accounts
-                    .get(ProviderState {
-                        status: GovernanceStatus::Inactive,
-                        payee: Payee::Dapp
-                    })
-                    .unwrap()
-                    .contains(&provider_account));
-
-                let url: Vec<u8> = vec![1, 2, 3];
-                let fee: u32 = 100;
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                let balance = 20000000000000;
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
-                contract.provider_update(url.clone(), fee, Payee::Dapp);
-                assert!(contract
-                    .provider_accounts
-                    .get(ProviderState {
-                        status: GovernanceStatus::Inactive,
-                        payee: Payee::Dapp
-                    })
-                    .unwrap()
-                    .contains(&provider_account));
-                let provider = contract.providers.get(provider_account).unwrap();
-                assert_eq!(provider.url, url);
-                assert_eq!(provider.fee, fee);
-                assert_eq!(provider.payee, Payee::Dapp);
-                assert_eq!(provider.balance, balance);
-                assert_eq!(provider.status, GovernanceStatus::Inactive);
-            }
-
-            /// Test provider register with url error
-            #[ink::test]
-            fn test_provider_register_with_url_error() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-
-                let (provider_account, url, fee) = generate_provider_data(0x2, "4242", 0);
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                contract
-                    .provider_register(url.clone(), fee, Payee::Dapp)
-                    .unwrap();
-
-                // try creating the second provider and make sure the error is correct and that it doesn't exist
-                let (provider_account, _, _) = generate_provider_data(0x3, "4242", 0);
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                println!("{:?}", contract.providers.get(provider_account));
-                match contract.provider_register(url, fee, Payee::Dapp) {
-                    Result::Err(Error::ProviderUrlUsed) => {}
-                    _ => {
-                        unreachable!();
-                    }
-                }
-                println!("{:?}", contract.providers.get(provider_account));
-                assert!(contract.providers.get(provider_account).is_none());
-                assert!(!contract
-                    .provider_accounts
-                    .get(ProviderState {
-                        status: GovernanceStatus::Inactive,
-                        payee: Payee::Dapp
-                    })
-                    .unwrap()
-                    .contains(&provider_account));
-            }
-
-            /// Test provider update with url error
-            #[ink::test]
-            fn test_provider_update_with_url_error() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-
-                let (provider_account, url, fee) = generate_provider_data(0x2, "4242", 0);
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                contract.provider_register(url, fee, Payee::Dapp).unwrap();
-
-                let (provider_account, url, fee) = generate_provider_data(0x3, "2424", 0);
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                contract.provider_register(url, fee, Payee::Dapp).unwrap();
-
-                let (_, url, fee) = generate_provider_data(0x3, "4242", 100);
-
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                let balance = 20000000000000;
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
-
-                // try updating the second provider and make sure the error is correct and that it didn't change
-                match contract.provider_update(url.clone(), fee, Payee::Dapp) {
-                    Result::Err(Error::ProviderUrlUsed) => {}
-                    _ => {
-                        unreachable!();
-                    }
-                }
-
-                let provider = contract.providers.get(provider_account).unwrap();
-                assert_ne!(provider.url, url);
-                assert_ne!(provider.fee, fee);
-                assert_ne!(provider.balance, balance);
-                assert_ne!(provider.status, GovernanceStatus::Active);
-            }
-
-            /// Test provider unstake
-            #[ink::test]
-            fn test_provider_deregister() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-                // give the contract some funds
-                set_account_balance(contract.env().account_id(), 1000000000);
-                let (provider_account, url, fee) = generate_provider_data(0x2, "4242", 0);
-                let balance: u128 = 10;
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                contract
-                    .provider_register(url.clone(), fee, Payee::Dapp)
-                    .ok();
-                ink::env::test::set_account_balance::<ink::env::DefaultEnvironment>(
-                    provider_account,
-                    balance,
+            let mut contract = get_contract(0);
+            let acc1 = AccountId::from([0x1; 32]);
+            let acc2 = AccountId::from([0x2; 32]);
+            const len: usize = 10;
+            let mut arr = [0; len];
+            // get several random numbers, one per block
+            for item in arr.iter_mut().take(len) {
+                let number = contract.get_random_number(100, acc1, acc2);
+                *item = number;
+                println!(
+                    "{:?} {:?} {:?}",
+                    number,
+                    ink::env::block_number::<ink::env::DefaultEnvironment>(),
+                    ink::env::block_timestamp::<ink::env::DefaultEnvironment>()
                 );
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
-                contract.provider_update(url, fee, Payee::Provider);
-                contract.provider_deregister().ok();
+                ink::env::test::advance_block::<ink::env::DefaultEnvironment>();
+            }
+            // check that the random numbers match precomputed values
+            assert_eq!(&[29, 95, 86, 92, 88, 24, 59, 73, 96, 53], &arr);
+        }
+
+        /// Helper function for converting string to Hash
+        fn str_to_hash(str: String) -> Hash {
+            let mut result = Hash::default();
+            let len_result = result.as_ref().len();
+            let mut hash_output = <<Blake2x256 as HashOutput>::Type as Default>::default();
+            <Blake2x256 as CryptoHash>::hash(str.as_ref(), &mut hash_output);
+            let copy_len = core::cmp::min(hash_output.len(), len_result);
+            result.as_mut()[0..copy_len].copy_from_slice(&hash_output[0..copy_len]);
+            result
+        }
+
+        /// Provider Register Helper
+        fn generate_provider_data(id: u8, port: &str, fee: u32) -> (AccountId, Vec<u8>, u32) {
+            let provider_account = AccountId::from([id; 32]);
+            let url = port.as_bytes().to_vec();
+
+            (provider_account, url, fee)
+        }
+
+        /// Test provider register and update
+        #[ink::test]
+        fn test_provider_register_and_update() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+            let (provider_account, url, fee) = generate_provider_data(0x2, "2424", 0);
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            contract.provider_register(url, fee, Payee::Dapp).unwrap();
+            assert!(contract.providers.get(provider_account).is_some());
+            assert!(contract
+                .provider_accounts
+                .get(ProviderState {
+                    status: GovernanceStatus::Inactive,
+                    payee: Payee::Dapp
+                })
+                .unwrap()
+                .contains(&provider_account));
+
+            let url: Vec<u8> = vec![1, 2, 3];
+            let fee: u32 = 100;
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            let balance = 20000000000000;
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
+            contract.provider_update(url.clone(), fee, Payee::Dapp);
+            assert!(contract
+                .provider_accounts
+                .get(ProviderState {
+                    status: GovernanceStatus::Inactive,
+                    payee: Payee::Dapp
+                })
+                .unwrap()
+                .contains(&provider_account));
+            let provider = contract.providers.get(provider_account).unwrap();
+            assert_eq!(provider.url, url);
+            assert_eq!(provider.fee, fee);
+            assert_eq!(provider.payee, Payee::Dapp);
+            assert_eq!(provider.balance, balance);
+            assert_eq!(provider.status, GovernanceStatus::Inactive);
+        }
+
+        /// Test provider register with url error
+        #[ink::test]
+        fn test_provider_register_with_url_error() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+
+            let (provider_account, url, fee) = generate_provider_data(0x2, "4242", 0);
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            contract
+                .provider_register(url.clone(), fee, Payee::Dapp)
+                .unwrap();
+
+            // try creating the second provider and make sure the error is correct and that it doesn't exist
+            let (provider_account, _, _) = generate_provider_data(0x3, "4242", 0);
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            println!("{:?}", contract.providers.get(provider_account));
+            match contract.provider_register(url, fee, Payee::Dapp) {
+                Result::Err(Error::ProviderUrlUsed) => {}
+                _ => {
+                    unreachable!();
+                }
+            }
+            println!("{:?}", contract.providers.get(provider_account));
+            assert!(contract.providers.get(provider_account).is_none());
+            assert!(!contract
+                .provider_accounts
+                .get(ProviderState {
+                    status: GovernanceStatus::Inactive,
+                    payee: Payee::Dapp
+                })
+                .unwrap()
+                .contains(&provider_account));
+        }
+
+        /// Test provider update with url error
+        #[ink::test]
+        fn test_provider_update_with_url_error() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+
+            let (provider_account, url, fee) = generate_provider_data(0x2, "4242", 0);
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            contract.provider_register(url, fee, Payee::Dapp).unwrap();
+
+            let (provider_account, url, fee) = generate_provider_data(0x3, "2424", 0);
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            contract.provider_register(url, fee, Payee::Dapp).unwrap();
+
+            let (_, url, fee) = generate_provider_data(0x3, "4242", 100);
+
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            let balance = 20000000000000;
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
+
+            // try updating the second provider and make sure the error is correct and that it didn't change
+            match contract.provider_update(url.clone(), fee, Payee::Dapp) {
+                Result::Err(Error::ProviderUrlUsed) => {}
+                _ => {
+                    unreachable!();
+                }
             }
 
-            /// Test provider add data set
-            #[ink::test]
-            fn test_provider_set_dataset() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
+            let provider = contract.providers.get(provider_account).unwrap();
+            assert_ne!(provider.url, url);
+            assert_ne!(provider.fee, fee);
+            assert_ne!(provider.balance, balance);
+            assert_ne!(provider.status, GovernanceStatus::Active);
+        }
 
-                let mut contract = get_contract(0);
-                let (provider_account, url, fee) = generate_provider_data(0x2, "4242", 0);
-                let balance: u128 = 2000000000000;
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                contract
-                    .provider_register(url.clone(), fee, Payee::Dapp)
-                    .ok();
-                ink::env::test::set_account_balance::<ink::env::DefaultEnvironment>(
-                    provider_account,
-                    balance,
-                );
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
-                contract.provider_update(url, fee, Payee::Provider);
-                let root1 = str_to_hash("merkle tree".to_string());
-                let root2 = str_to_hash("merkle tree2".to_string());
-                contract.provider_set_dataset(root1, root2).ok();
-            }
+        /// Test provider unstake
+        #[ink::test]
+        fn test_provider_deregister() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
 
-            /// Test dapp register with zero balance transfer
-            #[ink::test]
-            fn test_dapp_register_zero_balance_transfer() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
+            let mut contract = get_contract(0);
+            // give the contract some funds
+            set_account_balance(contract.env().account_id(), 1000000000);
+            let (provider_account, url, fee) = generate_provider_data(0x2, "4242", 0);
+            let balance: u128 = 10;
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            contract
+                .provider_register(url.clone(), fee, Payee::Dapp)
+                .ok();
+            ink::env::test::set_account_balance::<ink::env::DefaultEnvironment>(
+                provider_account,
+                balance,
+            );
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
+            contract.provider_update(url, fee, Payee::Provider);
+            contract.provider_deregister().ok();
+        }
 
-                let mut contract = get_contract(0);
-                let caller = AccountId::from([0x2; 32]);
-                let dapp_contract = AccountId::from([0x3; 32]);
-                // Call from the dapp account
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(caller);
-                // Don't transfer anything with the call
-                let balance = 0;
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
+        /// Test provider add data set
+        #[ink::test]
+        fn test_provider_set_dataset() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
 
-                // Mark the the dapp account as being a contract on-chain
-                ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract);
+            let mut contract = get_contract(0);
+            let (provider_account, url, fee) = generate_provider_data(0x2, "4242", 0);
+            let balance: u128 = 2000000000000;
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            contract
+                .provider_register(url.clone(), fee, Payee::Dapp)
+                .ok();
+            ink::env::test::set_account_balance::<ink::env::DefaultEnvironment>(
+                provider_account,
+                balance,
+            );
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
+            contract.provider_update(url, fee, Payee::Provider);
+            let root1 = str_to_hash("merkle tree".to_string());
+            let root2 = str_to_hash("merkle tree2".to_string());
+            contract.provider_set_dataset(root1, root2).ok();
+        }
 
-                contract.dapp_register(dapp_contract, DappPayee::Dapp);
-                assert!(contract.dapps.get(dapp_contract).is_some());
-                let dapp = contract.dapps.get(dapp_contract).unwrap();
-                assert_eq!(dapp.owner, caller);
+        /// Test dapp register with zero balance transfer
+        #[ink::test]
+        fn test_dapp_register_zero_balance_transfer() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
 
-                // account is marked as suspended as zero tokens have been paid
-                assert_eq!(dapp.status, GovernanceStatus::Inactive);
-                assert_eq!(dapp.balance, balance);
-                assert!(contract
-                    .dapp_accounts
-                    .get()
-                    .unwrap()
-                    .contains(&dapp_contract));
-            }
+            let mut contract = get_contract(0);
+            let caller = AccountId::from([0x2; 32]);
+            let dapp_contract = AccountId::from([0x3; 32]);
+            // Call from the dapp account
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(caller);
+            // Don't transfer anything with the call
+            let balance = 0;
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
 
-            /// Test dapp register with positive balance transfer
-            #[ink::test]
-            fn test_dapp_register_positive_balance_transfer() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
+            // Mark the the dapp account as being a contract on-chain
+            ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract);
 
-                let mut contract = get_contract(0);
-                let caller = AccountId::from([0x2; 32]);
-                let dapp_contract = AccountId::from([0x3; 32]);
+            contract.dapp_register(dapp_contract, DappPayee::Dapp);
+            assert!(contract.dapps.get(dapp_contract).is_some());
+            let dapp = contract.dapps.get(dapp_contract).unwrap();
+            assert_eq!(dapp.owner, caller);
 
-                // Call from the dapp account
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(caller);
+            // account is marked as suspended as zero tokens have been paid
+            assert_eq!(dapp.status, GovernanceStatus::Inactive);
+            assert_eq!(dapp.balance, balance);
+            assert!(contract
+                .dapp_accounts
+                .get()
+                .unwrap()
+                .contains(&dapp_contract));
+        }
 
-                // Transfer tokens with the call
-                let balance = STAKE_THRESHOLD;
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
+        /// Test dapp register with positive balance transfer
+        #[ink::test]
+        fn test_dapp_register_positive_balance_transfer() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
 
-                // Mark the the dapp account as being a contract on-chain
-                ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract);
+            let mut contract = get_contract(0);
+            let caller = AccountId::from([0x2; 32]);
+            let dapp_contract = AccountId::from([0x3; 32]);
 
-                // register the dapp
-                contract.dapp_register(dapp_contract, DappPayee::Dapp);
-                // check the dapp exists in the hashmap
-                assert!(contract.dapps.get(dapp_contract).is_some());
+            // Call from the dapp account
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(caller);
 
-                // check the various attributes are correct
-                let dapp = contract.dapps.get(dapp_contract).unwrap();
-                assert_eq!(dapp.owner, caller);
+            // Transfer tokens with the call
+            let balance = STAKE_THRESHOLD;
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
 
-                // account is marked as active as balance is now positive
-                assert_eq!(dapp.status, GovernanceStatus::Active);
-                assert_eq!(dapp.balance, balance);
-                assert!(contract
-                    .dapp_accounts
-                    .get()
-                    .unwrap()
-                    .contains(&dapp_contract));
-            }
+            // Mark the the dapp account as being a contract on-chain
+            ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract);
 
-            #[ink::test]
-            fn test_verify_sr25519_valid() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
+            // register the dapp
+            contract.dapp_register(dapp_contract, DappPayee::Dapp);
+            // check the dapp exists in the hashmap
+            assert!(contract.dapps.get(dapp_contract).is_some());
 
-                let mut contract = get_contract(0);
+            // check the various attributes are correct
+            let dapp = contract.dapps.get(dapp_contract).unwrap();
+            assert_eq!(dapp.owner, caller);
 
-                let data = "hello";
-                let mut data_hash = [0u8; 16];
-                Blake2x128::hash(data.as_bytes(), &mut data_hash);
-                println!("data_hash: {:?}", data_hash);
-                let data_hex = hex::encode(data_hash);
-                println!("data_hex: {:?}", data_hex);
-                // hex of prefix + hex of message hash + hex of suffix make the payload
-                let payload = "<Bytes>0x".to_string() + &data_hex + "</Bytes>";
-                println!("payload: {}", payload);
-                let payload_hex = hex::encode(payload);
-                println!("payload_hex: {}", payload_hex);
-                // put payload into bytes
-                let mut payload_bytes = [0u8; 49];
-                payload_bytes.copy_from_slice(hex::decode(payload_hex).unwrap().as_slice());
+            // account is marked as active as balance is now positive
+            assert_eq!(dapp.status, GovernanceStatus::Active);
+            assert_eq!(dapp.balance, balance);
+            assert!(contract
+                .dapp_accounts
+                .get()
+                .unwrap()
+                .contains(&dapp_contract));
+        }
 
-                // Test against a known signature
-                // sign the payload in polkjs. Note this will be different every time as signature changes randomly, but should always be valid
-                let signature_hex = "0a7da2b631704cdcfe93c740e41217b9ac667a0c8755d8da1a8232db527f487c87e780d2edc1896aeb6b1bef0bc7c38d9df2135b633eab8bfb1777e82fad3a8f";
-                println!("signature: {}", signature_hex);
-                let mut signature_bytes = [0u8; 64];
-                signature_bytes.copy_from_slice(hex::decode(signature_hex).unwrap().as_slice());
+        #[ink::test]
+        fn test_verify_sr25519_valid() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
 
-                const ALICE: [u8; 32] = [
-                    212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130,
-                    44, 133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125,
-                ];
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(AccountId::from(ALICE));
+            let mut contract = get_contract(0);
 
-                // verify the signature
-                contract
-                    .verify_sr25519(signature_bytes, payload_bytes)
+            let data = "hello";
+            let mut data_hash = [0u8; 16];
+            Blake2x128::hash(data.as_bytes(), &mut data_hash);
+            println!("data_hash: {:?}", data_hash);
+            let data_hex = hex::encode(data_hash);
+            println!("data_hex: {:?}", data_hex);
+            // hex of prefix + hex of message hash + hex of suffix make the payload
+            let payload = "<Bytes>0x".to_string() + &data_hex + "</Bytes>";
+            println!("payload: {}", payload);
+            let payload_hex = hex::encode(payload);
+            println!("payload_hex: {}", payload_hex);
+            // put payload into bytes
+            let mut payload_bytes = [0u8; 49];
+            payload_bytes.copy_from_slice(hex::decode(payload_hex).unwrap().as_slice());
+
+            // Test against a known signature
+            // sign the payload in polkjs. Note this will be different every time as signature changes randomly, but should always be valid
+            let signature_hex = "0a7da2b631704cdcfe93c740e41217b9ac667a0c8755d8da1a8232db527f487c87e780d2edc1896aeb6b1bef0bc7c38d9df2135b633eab8bfb1777e82fad3a8f";
+            println!("signature: {}", signature_hex);
+            let mut signature_bytes = [0u8; 64];
+            signature_bytes.copy_from_slice(hex::decode(signature_hex).unwrap().as_slice());
+
+            const ALICE: [u8; 32] = [
+                212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130, 44,
+                133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125,
+            ];
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(AccountId::from(ALICE));
+
+            // verify the signature
+            contract
+                .verify_sr25519(signature_bytes, payload_bytes)
+                .unwrap();
+        }
+
+        #[ink::test]
+        fn test_verify_sr25519_invalid_signature() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+
+            let data = "hello";
+            let mut data_hash = [0u8; 16];
+            Blake2x128::hash(data.as_bytes(), &mut data_hash);
+            println!("data_hash: {:?}", data_hash);
+            let data_hex = hex::encode(data_hash);
+            println!("data_hex: {:?}", data_hex);
+            // hex of prefix + hex of message hash + hex of suffix make the payload
+            let payload = "<Bytes>0x".to_string() + &data_hex + "</Bytes>";
+            println!("payload: {}", payload);
+            let payload_hex = hex::encode(payload);
+            println!("payload_hex: {}", payload_hex);
+            // put payload into bytes
+            let mut payload_bytes = [0u8; 49];
+            payload_bytes.copy_from_slice(hex::decode(payload_hex).unwrap().as_slice());
+
+            // Test against a known signature
+            // sign the payload in polkjs. Note this will be different every time as signature changes randomly, but should always be valid
+            let signature_hex = "1a7da2b631704cdcfe93c740e41217b9ac667a0c8755d8da1a8232db527f487c87e780d2edc1896aeb6b1bef0bc7c38d9df2135b633eab8bfb1777e82fad3a8f";
+            println!("signature: {}", signature_hex);
+            let mut signature_bytes = [0u8; 64];
+            signature_bytes.copy_from_slice(hex::decode(signature_hex).unwrap().as_slice());
+
+            const ALICE: [u8; 32] = [
+                212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130, 44,
+                133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125,
+            ];
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(AccountId::from(ALICE));
+
+            // verify the signature
+            contract
+                .verify_sr25519(signature_bytes, payload_bytes)
+                .unwrap_err();
+        }
+
+        #[ink::test]
+        #[should_panic]
+        fn test_verify_sr25519_invalid_public_key() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+
+            let data = "hello";
+            let mut data_hash = [0u8; 16];
+            Blake2x128::hash(data.as_bytes(), &mut data_hash);
+            println!("data_hash: {:?}", data_hash);
+            let data_hex = hex::encode(data_hash);
+            println!("data_hex: {:?}", data_hex);
+            // hex of prefix + hex of message hash + hex of suffix make the payload
+            let payload = "<Bytes>0x".to_string() + &data_hex + "</Bytes>";
+            println!("payload: {}", payload);
+            let payload_hex = hex::encode(payload);
+            println!("payload_hex: {}", payload_hex);
+            // put payload into bytes
+            let mut payload_bytes = [0u8; 49];
+            payload_bytes.copy_from_slice(hex::decode(payload_hex).unwrap().as_slice());
+
+            // Test against a known signature
+            // sign the payload in polkjs. Note this will be different every time as signature changes randomly, but should always be valid
+            let signature_hex = "0a7da2b631704cdcfe93c740e41217b9ac667a0c8755d8da1a8232db527f487c87e780d2edc1896aeb6b1bef0bc7c38d9df2135b633eab8bfb1777e82fad3a8f";
+            println!("signature: {}", signature_hex);
+            let mut signature_bytes = [0u8; 64];
+            signature_bytes.copy_from_slice(hex::decode(signature_hex).unwrap().as_slice());
+
+            const ALICE: [u8; 32] = [
+                213, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130, 44,
+                133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125,
+            ];
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(AccountId::from(ALICE));
+
+            // verify the signature
+            let valid = contract.verify_sr25519(signature_bytes, payload_bytes);
+        }
+
+        #[ink::test]
+        fn test_verify_sr25519_invalid_data() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+
+            let data = "hello2";
+            let mut data_hash = [0u8; 16];
+            Blake2x128::hash(data.as_bytes(), &mut data_hash);
+            println!("data_hash: {:?}", data_hash);
+            let data_hex = hex::encode(data_hash);
+            println!("data_hex: {:?}", data_hex);
+            // hex of prefix + hex of message hash + hex of suffix make the payload
+            let payload = "<Bytes>0x".to_string() + &data_hex + "</Bytes>";
+            println!("payload: {}", payload);
+            let payload_hex = hex::encode(payload);
+            println!("payload_hex: {}", payload_hex);
+            // put payload into bytes
+            let mut payload_bytes = [0u8; 49];
+            payload_bytes.copy_from_slice(hex::decode(payload_hex).unwrap().as_slice());
+
+            // Test against a known signature
+            // sign the payload in polkjs. Note this will be different every time as signature changes randomly, but should always be valid
+            let signature_hex = "0a7da2b631704cdcfe93c740e41217b9ac667a0c8755d8da1a8232db527f487c87e780d2edc1896aeb6b1bef0bc7c38d9df2135b633eab8bfb1777e82fad3a8f";
+            println!("signature: {}", signature_hex);
+            let mut signature_bytes = [0u8; 64];
+            signature_bytes.copy_from_slice(hex::decode(signature_hex).unwrap().as_slice());
+
+            const ALICE: [u8; 32] = [
+                212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130, 44,
+                133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125,
+            ];
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(AccountId::from(ALICE));
+
+            // verify the signature
+            contract
+                .verify_sr25519(signature_bytes, payload_bytes)
+                .unwrap_err();
+        }
+
+        #[ink::test]
+        fn test_verify_sr25519_invalid_payload() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+
+            let data = "hello";
+            let mut data_hash = [0u8; 16];
+            Blake2x128::hash(data.as_bytes(), &mut data_hash);
+            println!("data_hash: {:?}", data_hash);
+            let data_hex = hex::encode(data_hash);
+            println!("data_hex: {:?}", data_hex);
+            // hex of prefix + hex of message hash + hex of suffix make the payload
+            let payload = "<Aytes>0x".to_string() + &data_hex + "</Bytes>";
+            println!("payload: {}", payload);
+            let payload_hex = hex::encode(payload);
+            println!("payload_hex: {}", payload_hex);
+            // put payload into bytes
+            let mut payload_bytes = [0u8; 49];
+            payload_bytes.copy_from_slice(hex::decode(payload_hex).unwrap().as_slice());
+
+            // Test against a known signature
+            // sign the payload in polkjs. Note this will be different every time as signature changes randomly, but should always be valid
+            let signature_hex = "0a7da2b631704cdcfe93c740e41217b9ac667a0c8755d8da1a8232db527f487c87e780d2edc1896aeb6b1bef0bc7c38d9df2135b633eab8bfb1777e82fad3a8f";
+            println!("signature: {}", signature_hex);
+            let mut signature_bytes = [0u8; 64];
+            signature_bytes.copy_from_slice(hex::decode(signature_hex).unwrap().as_slice());
+
+            const ALICE: [u8; 32] = [
+                212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130, 44,
+                133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125,
+            ];
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(AccountId::from(ALICE));
+
+            // verify the signature
+            contract
+                .verify_sr25519(signature_bytes, payload_bytes)
+                .unwrap_err();
+        }
+
+        /// Test dapp register and then update
+        #[ink::test]
+        fn test_dapp_register_and_update() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+            let caller = AccountId::from([0x2; 32]);
+            let dapp_contract_account = AccountId::from([0x3; 32]);
+
+            // Call from the dapp account
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(caller);
+
+            // Transfer tokens with the call
+            let balance_1 = STAKE_THRESHOLD;
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance_1);
+
+            // Mark the the dapp account as being a contract on-chain
+            ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract_account);
+
+            // register the dapp
+            contract.dapp_register(dapp_contract_account, DappPayee::Dapp);
+
+            // check the dapp exists in the hashmap
+            assert!(contract.dapps.get(dapp_contract_account).is_some());
+
+            // check the various attributes are correct
+            let dapp = contract.dapps.get(dapp_contract_account).unwrap();
+            assert_eq!(dapp.owner, caller);
+
+            // account is marked as active as tokens have been paid
+            assert_eq!(dapp.status, GovernanceStatus::Active);
+            assert_eq!(dapp.balance, balance_1);
+
+            // Transfer tokens with the call
+            let balance_2 = STAKE_THRESHOLD;
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance_2);
+
+            // run the register function again for the same (caller, contract) pair, adding more
+            // tokens
+            contract.dapp_update(dapp_contract_account, DappPayee::Any, caller);
+
+            // check the various attributes are correct
+            let dapp = contract.dapps.get(dapp_contract_account).unwrap();
+
+            // account is marked as active as tokens have been paid
+            assert_eq!(dapp.status, GovernanceStatus::Active);
+            assert_eq!(dapp.balance, balance_1 + balance_2);
+            assert!(contract
+                .dapp_accounts
+                .get()
+                .unwrap()
+                .contains(&dapp_contract_account));
+        }
+
+        /// Test dapp fund account
+        #[ink::test]
+        fn test_dapp_fund() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+            let caller = AccountId::from([0x2; 32]);
+            let dapp_contract = AccountId::from([0x3; 32]);
+
+            // Call from the dapp account
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(caller);
+
+            // Transfer tokens with the register call
+            let balance_1 = 100;
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance_1);
+
+            // Mark the the dapp account as being a contract on-chain
+            ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract);
+
+            // register the dapp
+            contract.dapp_register(dapp_contract, DappPayee::Dapp);
+
+            // Transfer tokens with the fund call
+            let balance_2 = 200;
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance_2);
+            contract.dapp_fund(dapp_contract);
+
+            // check the total account balance is correct
+            let dapp = contract.dapps.get(dapp_contract).unwrap();
+            assert_eq!(dapp.balance, balance_1 + balance_2);
+        }
+
+        /// Test dapp cancel
+        #[ink::test]
+        fn test_dapp_cancel() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+            // give the contract some funds
+            set_account_balance(contract.env().account_id(), 1000000000);
+            let caller = AccountId::from([0x2; 32]);
+            let contract_account = AccountId::from([0x3; 32]);
+            let callers_initial_balance =
+                ink::env::test::get_account_balance::<ink::env::DefaultEnvironment>(caller)
                     .unwrap();
-            }
 
-            #[ink::test]
-            fn test_verify_sr25519_invalid_signature() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
+            // Mark the the dapp account as being a contract on-chain
+            ink::env::test::set_contract::<ink::env::DefaultEnvironment>(contract_account);
 
-                let mut contract = get_contract(0);
+            // Make sure the dapp account is a contract
+            let result =
+                ink::env::test::is_contract::<ink::env::DefaultEnvironment>(contract_account);
+            assert!(result);
 
-                let data = "hello";
-                let mut data_hash = [0u8; 16];
-                Blake2x128::hash(data.as_bytes(), &mut data_hash);
-                println!("data_hash: {:?}", data_hash);
-                let data_hex = hex::encode(data_hash);
-                println!("data_hex: {:?}", data_hex);
-                // hex of prefix + hex of message hash + hex of suffix make the payload
-                let payload = "<Bytes>0x".to_string() + &data_hex + "</Bytes>";
-                println!("payload: {}", payload);
-                let payload_hex = hex::encode(payload);
-                println!("payload_hex: {}", payload_hex);
-                // put payload into bytes
-                let mut payload_bytes = [0u8; 49];
-                payload_bytes.copy_from_slice(hex::decode(payload_hex).unwrap().as_slice());
+            // Call from the dapp account
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(caller);
 
-                // Test against a known signature
-                // sign the payload in polkjs. Note this will be different every time as signature changes randomly, but should always be valid
-                let signature_hex = "1a7da2b631704cdcfe93c740e41217b9ac667a0c8755d8da1a8232db527f487c87e780d2edc1896aeb6b1bef0bc7c38d9df2135b633eab8bfb1777e82fad3a8f";
-                println!("signature: {}", signature_hex);
-                let mut signature_bytes = [0u8; 64];
-                signature_bytes.copy_from_slice(hex::decode(signature_hex).unwrap().as_slice());
+            // Transfer tokens with the register call
+            let balance = 200;
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
 
-                const ALICE: [u8; 32] = [
-                    212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130,
-                    44, 133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125,
-                ];
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(AccountId::from(ALICE));
+            // register the dapp
+            contract.dapp_register(contract_account, DappPayee::Dapp);
 
-                // verify the signature
-                contract
-                    .verify_sr25519(signature_bytes, payload_bytes)
-                    .unwrap_err();
-            }
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(0);
 
-            #[ink::test]
-            #[should_panic]
-            fn test_verify_sr25519_invalid_public_key() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
+            // Transfer tokens with the fund call
+            contract.dapp_deregister(contract_account).ok();
 
-                let mut contract = get_contract(0);
+            // check the dapp has been removed
+            assert!(contract.dapps.get(contract_account).is_none());
 
-                let data = "hello";
-                let mut data_hash = [0u8; 16];
-                Blake2x128::hash(data.as_bytes(), &mut data_hash);
-                println!("data_hash: {:?}", data_hash);
-                let data_hex = hex::encode(data_hash);
-                println!("data_hex: {:?}", data_hex);
-                // hex of prefix + hex of message hash + hex of suffix make the payload
-                let payload = "<Bytes>0x".to_string() + &data_hex + "</Bytes>";
-                println!("payload: {}", payload);
-                let payload_hex = hex::encode(payload);
-                println!("payload_hex: {}", payload_hex);
-                // put payload into bytes
-                let mut payload_bytes = [0u8; 49];
-                payload_bytes.copy_from_slice(hex::decode(payload_hex).unwrap().as_slice());
-
-                // Test against a known signature
-                // sign the payload in polkjs. Note this will be different every time as signature changes randomly, but should always be valid
-                let signature_hex = "0a7da2b631704cdcfe93c740e41217b9ac667a0c8755d8da1a8232db527f487c87e780d2edc1896aeb6b1bef0bc7c38d9df2135b633eab8bfb1777e82fad3a8f";
-                println!("signature: {}", signature_hex);
-                let mut signature_bytes = [0u8; 64];
-                signature_bytes.copy_from_slice(hex::decode(signature_hex).unwrap().as_slice());
-
-                const ALICE: [u8; 32] = [
-                    213, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130,
-                    44, 133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125,
-                ];
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(AccountId::from(ALICE));
-
-                // verify the signature
-                let valid = contract.verify_sr25519(signature_bytes, payload_bytes);
-            }
-
-            #[ink::test]
-            fn test_verify_sr25519_invalid_data() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-
-                let data = "hello2";
-                let mut data_hash = [0u8; 16];
-                Blake2x128::hash(data.as_bytes(), &mut data_hash);
-                println!("data_hash: {:?}", data_hash);
-                let data_hex = hex::encode(data_hash);
-                println!("data_hex: {:?}", data_hex);
-                // hex of prefix + hex of message hash + hex of suffix make the payload
-                let payload = "<Bytes>0x".to_string() + &data_hex + "</Bytes>";
-                println!("payload: {}", payload);
-                let payload_hex = hex::encode(payload);
-                println!("payload_hex: {}", payload_hex);
-                // put payload into bytes
-                let mut payload_bytes = [0u8; 49];
-                payload_bytes.copy_from_slice(hex::decode(payload_hex).unwrap().as_slice());
-
-                // Test against a known signature
-                // sign the payload in polkjs. Note this will be different every time as signature changes randomly, but should always be valid
-                let signature_hex = "0a7da2b631704cdcfe93c740e41217b9ac667a0c8755d8da1a8232db527f487c87e780d2edc1896aeb6b1bef0bc7c38d9df2135b633eab8bfb1777e82fad3a8f";
-                println!("signature: {}", signature_hex);
-                let mut signature_bytes = [0u8; 64];
-                signature_bytes.copy_from_slice(hex::decode(signature_hex).unwrap().as_slice());
-
-                const ALICE: [u8; 32] = [
-                    212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130,
-                    44, 133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125,
-                ];
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(AccountId::from(ALICE));
-
-                // verify the signature
-                contract
-                    .verify_sr25519(signature_bytes, payload_bytes)
-                    .unwrap_err();
-            }
-
-            #[ink::test]
-            fn test_verify_sr25519_invalid_payload() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-
-                let data = "hello";
-                let mut data_hash = [0u8; 16];
-                Blake2x128::hash(data.as_bytes(), &mut data_hash);
-                println!("data_hash: {:?}", data_hash);
-                let data_hex = hex::encode(data_hash);
-                println!("data_hex: {:?}", data_hex);
-                // hex of prefix + hex of message hash + hex of suffix make the payload
-                let payload = "<Aytes>0x".to_string() + &data_hex + "</Bytes>";
-                println!("payload: {}", payload);
-                let payload_hex = hex::encode(payload);
-                println!("payload_hex: {}", payload_hex);
-                // put payload into bytes
-                let mut payload_bytes = [0u8; 49];
-                payload_bytes.copy_from_slice(hex::decode(payload_hex).unwrap().as_slice());
-
-                // Test against a known signature
-                // sign the payload in polkjs. Note this will be different every time as signature changes randomly, but should always be valid
-                let signature_hex = "0a7da2b631704cdcfe93c740e41217b9ac667a0c8755d8da1a8232db527f487c87e780d2edc1896aeb6b1bef0bc7c38d9df2135b633eab8bfb1777e82fad3a8f";
-                println!("signature: {}", signature_hex);
-                let mut signature_bytes = [0u8; 64];
-                signature_bytes.copy_from_slice(hex::decode(signature_hex).unwrap().as_slice());
-
-                const ALICE: [u8; 32] = [
-                    212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130,
-                    44, 133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125,
-                ];
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(AccountId::from(ALICE));
-
-                // verify the signature
-                contract
-                    .verify_sr25519(signature_bytes, payload_bytes)
-                    .unwrap_err();
-            }
-
-            /// Test dapp register and then update
-            #[ink::test]
-            fn test_dapp_register_and_update() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-                let caller = AccountId::from([0x2; 32]);
-                let dapp_contract_account = AccountId::from([0x3; 32]);
-
-                // Call from the dapp account
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(caller);
-
-                // Transfer tokens with the call
-                let balance_1 = STAKE_THRESHOLD;
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance_1);
-
-                // Mark the the dapp account as being a contract on-chain
-                ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract_account);
-
-                // register the dapp
-                contract.dapp_register(dapp_contract_account, DappPayee::Dapp);
-
-                // check the dapp exists in the hashmap
-                assert!(contract.dapps.get(dapp_contract_account).is_some());
-
-                // check the various attributes are correct
-                let dapp = contract.dapps.get(dapp_contract_account).unwrap();
-                assert_eq!(dapp.owner, caller);
-
-                // account is marked as active as tokens have been paid
-                assert_eq!(dapp.status, GovernanceStatus::Active);
-                assert_eq!(dapp.balance, balance_1);
-
-                // Transfer tokens with the call
-                let balance_2 = STAKE_THRESHOLD;
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance_2);
-
-                // run the register function again for the same (caller, contract) pair, adding more
-                // tokens
-                contract.dapp_update(dapp_contract_account, DappPayee::Any, caller);
-
-                // check the various attributes are correct
-                let dapp = contract.dapps.get(dapp_contract_account).unwrap();
-
-                // account is marked as active as tokens have been paid
-                assert_eq!(dapp.status, GovernanceStatus::Active);
-                assert_eq!(dapp.balance, balance_1 + balance_2);
-                assert!(contract
-                    .dapp_accounts
-                    .get()
-                    .unwrap()
-                    .contains(&dapp_contract_account));
-            }
-
-            /// Test dapp fund account
-            #[ink::test]
-            fn test_dapp_fund() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-                let caller = AccountId::from([0x2; 32]);
-                let dapp_contract = AccountId::from([0x3; 32]);
-
-                // Call from the dapp account
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(caller);
-
-                // Transfer tokens with the register call
-                let balance_1 = 100;
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance_1);
-
-                // Mark the the dapp account as being a contract on-chain
-                ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract);
-
-                // register the dapp
-                contract.dapp_register(dapp_contract, DappPayee::Dapp);
-
-                // Transfer tokens with the fund call
-                let balance_2 = 200;
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance_2);
-                contract.dapp_fund(dapp_contract);
-
-                // check the total account balance is correct
-                let dapp = contract.dapps.get(dapp_contract).unwrap();
-                assert_eq!(dapp.balance, balance_1 + balance_2);
-            }
-
-            /// Test dapp cancel
-            #[ink::test]
-            fn test_dapp_cancel() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-                // give the contract some funds
-                set_account_balance(contract.env().account_id(), 1000000000);
-                let caller = AccountId::from([0x2; 32]);
-                let contract_account = AccountId::from([0x3; 32]);
-                let callers_initial_balance =
-                    ink::env::test::get_account_balance::<ink::env::DefaultEnvironment>(caller)
-                        .unwrap();
-
-                // Mark the the dapp account as being a contract on-chain
-                ink::env::test::set_contract::<ink::env::DefaultEnvironment>(contract_account);
-
-                // Make sure the dapp account is a contract
-                let result =
-                    ink::env::test::is_contract::<ink::env::DefaultEnvironment>(contract_account);
-                assert!(result);
-
-                // Call from the dapp account
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(caller);
-
-                // Transfer tokens with the register call
-                let balance = 200;
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
-
-                // register the dapp
-                contract.dapp_register(contract_account, DappPayee::Dapp);
-
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(0);
-
-                // Transfer tokens with the fund call
-                contract.dapp_deregister(contract_account).ok();
-
-                // check the dapp has been removed
-                assert!(contract.dapps.get(contract_account).is_none());
-
-                // Make sure the funds are returned to the caller
-                let callers_balance =
-                    ink::env::test::get_account_balance::<ink::env::DefaultEnvironment>(caller)
-                        .unwrap();
-                assert_eq!(callers_initial_balance + balance, callers_balance);
-            }
-
-            /// Test provider approve
-            #[ink::test]
-            fn test_provider_approve() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-
-                // Register the provider
-                let (provider_account, url, fee) = generate_provider_data(0x2, "4242", 1);
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                contract
-                    .provider_register(url.clone(), fee, Payee::Dapp)
+            // Make sure the funds are returned to the caller
+            let callers_balance =
+                ink::env::test::get_account_balance::<ink::env::DefaultEnvironment>(caller)
                     .unwrap();
+            assert_eq!(callers_initial_balance + balance, callers_balance);
+        }
 
-                // Call from the provider account to add data and stake tokens
-                let balance = 2000000000000;
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                let root1 = str_to_hash("merkle tree1".to_string());
-                let root2 = str_to_hash("merkle tree2".to_string());
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
-                contract.provider_update(url, fee, Payee::Provider);
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(0);
+        /// Test provider approve
+        #[ink::test]
+        fn test_provider_approve() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
 
-                let provider = contract.providers.get(provider_account).unwrap();
-                // can only add data set after staking
-                contract.provider_set_dataset(root1, root2).ok();
+            let mut contract = get_contract(0);
 
-                // Register the dapp
-                let dapp_caller_account = AccountId::from([0x3; 32]);
-                let dapp_contract_account = AccountId::from([0x4; 32]);
-                // Mark the the dapp account as being a contract on-chain
-                ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract_account);
+            // Register the provider
+            let (provider_account, url, fee) = generate_provider_data(0x2, "4242", 1);
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            contract
+                .provider_register(url.clone(), fee, Payee::Dapp)
+                .unwrap();
 
-                // Call from the dapp account
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(dapp_caller_account);
-                // Give the dap a balance
-                let balance = 2000000000000;
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
-                contract.dapp_register(dapp_contract_account, DappPayee::Dapp);
+            // Call from the provider account to add data and stake tokens
+            let balance = 2000000000000;
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            let root1 = str_to_hash("merkle tree1".to_string());
+            let root2 = str_to_hash("merkle tree2".to_string());
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
+            contract.provider_update(url, fee, Payee::Provider);
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(0);
 
-                //Dapp User commit
-                let dapp_user_account = AccountId::from([0x5; 32]);
-                let user_root = str_to_hash("user merkle tree root".to_string());
+            let provider = contract.providers.get(provider_account).unwrap();
+            // can only add data set after staking
+            contract.provider_set_dataset(root1, root2).ok();
 
-                // Call from the provider account to mark the solution as approved
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                let solution_id = user_root;
-                contract.provider_commit(Commit {
-                    dapp: dapp_contract_account,
-                    dataset_id: user_root,
-                    status: CaptchaStatus::Approved,
-                    provider: provider_account,
-                    user: dapp_user_account,
-                    completed_at: 0,
-                    requested_at: 0,
-                    id: solution_id,
-                    user_signature: Vec::new(),
-                });
-                let commitment = contract
-                    .captcha_solution_commitments
-                    .get(solution_id)
-                    .unwrap();
-                assert_eq!(commitment.status, CaptchaStatus::Approved);
-                let new_dapp_balance = contract.get_dapp_balance(dapp_contract_account).unwrap();
-                let new_provider_balance = contract.get_provider_balance(provider_account).unwrap();
-                assert_eq!(balance - Balance::from(fee), new_dapp_balance);
-                assert_eq!(balance + Balance::from(fee), new_provider_balance);
+            // Register the dapp
+            let dapp_caller_account = AccountId::from([0x3; 32]);
+            let dapp_contract_account = AccountId::from([0x4; 32]);
+            // Mark the the dapp account as being a contract on-chain
+            ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract_account);
 
-                // Now make sure that the provider cannot later set the solution to disapproved and make
-                // sure that the dapp balance is unchanged
+            // Call from the dapp account
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(dapp_caller_account);
+            // Give the dap a balance
+            let balance = 2000000000000;
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
+            contract.dapp_register(dapp_contract_account, DappPayee::Dapp);
 
-                contract.provider_commit(Commit {
+            //Dapp User commit
+            let dapp_user_account = AccountId::from([0x5; 32]);
+            let user_root = str_to_hash("user merkle tree root".to_string());
+
+            // Call from the provider account to mark the solution as approved
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            let solution_id = user_root;
+            contract.provider_commit(Commit {
+                dapp: dapp_contract_account,
+                dataset_id: user_root,
+                status: CaptchaStatus::Approved,
+                provider: provider_account,
+                user: dapp_user_account,
+                completed_at: 0,
+                requested_at: 0,
+                id: solution_id,
+                user_signature: Vec::new(),
+            });
+            let commitment = contract
+                .captcha_solution_commitments
+                .get(solution_id)
+                .unwrap();
+            assert_eq!(commitment.status, CaptchaStatus::Approved);
+            let new_dapp_balance = contract.get_dapp_balance(dapp_contract_account).unwrap();
+            let new_provider_balance = contract.get_provider_balance(provider_account).unwrap();
+            assert_eq!(balance - Balance::from(fee), new_dapp_balance);
+            assert_eq!(balance + Balance::from(fee), new_provider_balance);
+
+            // Now make sure that the provider cannot later set the solution to disapproved and make
+            // sure that the dapp balance is unchanged
+
+            contract.provider_commit(Commit {
+                dapp: dapp_contract_account,
+                dataset_id: user_root,
+                status: CaptchaStatus::Disapproved,
+                provider: provider_account,
+                user: dapp_user_account,
+                completed_at: 0,
+                requested_at: 0,
+                id: solution_id,
+                user_signature: Vec::new(),
+            });
+            let commitment = contract
+                .captcha_solution_commitments
+                .get(solution_id)
+                .unwrap();
+            assert_eq!(commitment.status, CaptchaStatus::Approved);
+            assert_eq!(
+                balance - Balance::from(fee),
+                contract.get_dapp_balance(dapp_contract_account).unwrap()
+            );
+            assert_eq!(
+                balance + Balance::from(fee),
+                contract.get_provider_balance(provider_account).unwrap()
+            );
+        }
+
+        /// Test provider cannot approve invalid solution id
+        #[ink::test]
+        fn test_provider_approve_invalid_id() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+
+            // Register the provider
+            let (provider_account, url, fee) = generate_provider_data(0x2, "4242", 0);
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            contract
+                .provider_register(url.clone(), fee, Payee::Dapp)
+                .unwrap();
+
+            // Call from the provider account to add data and stake tokens
+            let balance = 2000000000000;
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            let root1 = str_to_hash("merkle tree1".to_string());
+            let root2 = str_to_hash("merkle tree2".to_string());
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
+            contract.provider_update(url, fee, Payee::Provider);
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(0);
+
+            // can only add data set after staking
+            contract.provider_set_dataset(root1, root2).ok();
+
+            // Register the dapp
+            let dapp_caller_account = AccountId::from([0x3; 32]);
+            let dapp_contract_account = AccountId::from([0x4; 32]);
+            // Mark the the dapp account as being a contract on-chain
+            ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract_account);
+
+            // Call from the dapp account
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(dapp_caller_account);
+            // Give the dap a balance
+            let balance = 2000000000000;
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
+            contract.dapp_register(dapp_contract_account, DappPayee::Dapp);
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(0);
+
+            //Dapp User commit
+            let dapp_user_account = AccountId::from([0x5; 32]);
+            let user_root = str_to_hash("user merkle tree root".to_string());
+
+            // Call from the provider account to mark the wrong solution as approved
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            let solution_id = str_to_hash("id that does not exist".to_string());
+
+            let result = contract.provider_commit(Commit {
+                dapp: dapp_contract_account,
+                dataset_id: user_root,
+                status: CaptchaStatus::Approved,
+                provider: provider_account,
+                user: dapp_user_account,
+                completed_at: 0,
+                requested_at: 0,
+                id: solution_id,
+                user_signature: Vec::new(),
+            });
+        }
+
+        /// Test provider disapprove
+        #[ink::test]
+        fn test_provider_disapprove() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+
+            // Register the provider
+            let (provider_account, url, fee) = generate_provider_data(0x2, "4242", 1);
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            contract
+                .provider_register(url.clone(), fee, Payee::Dapp)
+                .unwrap();
+
+            // Call from the provider account to add data and stake tokens
+            let balance = 2000000000000;
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            let root1 = str_to_hash("merkle tree1".to_string());
+            let root2 = str_to_hash("merkle tree2".to_string());
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
+            contract.provider_update(url, fee, Payee::Provider).unwrap();
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(0);
+
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(0);
+            // can only add data set after staking
+            contract.provider_set_dataset(root1, root2).unwrap();
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(0);
+
+            // Register the dapp
+            let dapp_caller_account = AccountId::from([0x3; 32]);
+            let dapp_contract_account = AccountId::from([0x4; 32]);
+            // Mark the the dapp account as being a contract on-chain
+            ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract_account);
+
+            // Call from the dapp account
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(dapp_caller_account);
+            // Give the dap a balance
+            let balance = 2000000000000;
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
+            contract
+                .dapp_register(dapp_contract_account, DappPayee::Dapp)
+                .unwrap();
+
+            //Dapp User commit
+            let dapp_user_account = AccountId::from([0x5; 32]);
+            let user_root = str_to_hash("user merkle tree root".to_string());
+
+            // Call from the provider account to mark the solution as disapproved
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            let solution_id = user_root;
+            contract
+                .provider_commit(Commit {
                     dapp: dapp_contract_account,
                     dataset_id: user_root,
                     status: CaptchaStatus::Disapproved,
@@ -2764,561 +2902,416 @@ pub mod prosopo {
                     requested_at: 0,
                     id: solution_id,
                     user_signature: Vec::new(),
-                });
-                let commitment = contract
-                    .captcha_solution_commitments
-                    .get(solution_id)
-                    .unwrap();
-                assert_eq!(commitment.status, CaptchaStatus::Approved);
-                assert_eq!(
-                    balance - Balance::from(fee),
-                    contract.get_dapp_balance(dapp_contract_account).unwrap()
-                );
-                assert_eq!(
-                    balance + Balance::from(fee),
-                    contract.get_provider_balance(provider_account).unwrap()
-                );
-            }
-
-            /// Test provider cannot approve invalid solution id
-            #[ink::test]
-            fn test_provider_approve_invalid_id() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-
-                // Register the provider
-                let (provider_account, url, fee) = generate_provider_data(0x2, "4242", 0);
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                contract
-                    .provider_register(url.clone(), fee, Payee::Dapp)
-                    .unwrap();
-
-                // Call from the provider account to add data and stake tokens
-                let balance = 2000000000000;
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                let root1 = str_to_hash("merkle tree1".to_string());
-                let root2 = str_to_hash("merkle tree2".to_string());
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
-                contract.provider_update(url, fee, Payee::Provider);
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(0);
-
-                // can only add data set after staking
-                contract.provider_set_dataset(root1, root2).ok();
-
-                // Register the dapp
-                let dapp_caller_account = AccountId::from([0x3; 32]);
-                let dapp_contract_account = AccountId::from([0x4; 32]);
-                // Mark the the dapp account as being a contract on-chain
-                ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract_account);
-
-                // Call from the dapp account
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(dapp_caller_account);
-                // Give the dap a balance
-                let balance = 2000000000000;
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
-                contract.dapp_register(dapp_contract_account, DappPayee::Dapp);
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(0);
-
-                //Dapp User commit
-                let dapp_user_account = AccountId::from([0x5; 32]);
-                let user_root = str_to_hash("user merkle tree root".to_string());
-
-                // Call from the provider account to mark the wrong solution as approved
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                let solution_id = str_to_hash("id that does not exist".to_string());
-
-                let result = contract.provider_commit(Commit {
-                    dapp: dapp_contract_account,
-                    dataset_id: user_root,
-                    status: CaptchaStatus::Approved,
-                    provider: provider_account,
-                    user: dapp_user_account,
-                    completed_at: 0,
-                    requested_at: 0,
-                    id: solution_id,
-                    user_signature: Vec::new(),
-                });
-            }
-
-            /// Test provider disapprove
-            #[ink::test]
-            fn test_provider_disapprove() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-
-                // Register the provider
-                let (provider_account, url, fee) = generate_provider_data(0x2, "4242", 1);
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                contract
-                    .provider_register(url.clone(), fee, Payee::Dapp)
-                    .unwrap();
-
-                // Call from the provider account to add data and stake tokens
-                let balance = 2000000000000;
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                let root1 = str_to_hash("merkle tree1".to_string());
-                let root2 = str_to_hash("merkle tree2".to_string());
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
-                contract.provider_update(url, fee, Payee::Provider).unwrap();
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(0);
-
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(0);
-                // can only add data set after staking
-                contract.provider_set_dataset(root1, root2).unwrap();
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(0);
-
-                // Register the dapp
-                let dapp_caller_account = AccountId::from([0x3; 32]);
-                let dapp_contract_account = AccountId::from([0x4; 32]);
-                // Mark the the dapp account as being a contract on-chain
-                ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract_account);
-
-                // Call from the dapp account
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(dapp_caller_account);
-                // Give the dap a balance
-                let balance = 2000000000000;
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
-                contract
-                    .dapp_register(dapp_contract_account, DappPayee::Dapp)
-                    .unwrap();
-
-                //Dapp User commit
-                let dapp_user_account = AccountId::from([0x5; 32]);
-                let user_root = str_to_hash("user merkle tree root".to_string());
-
-                // Call from the provider account to mark the solution as disapproved
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                let solution_id = user_root;
-                contract
-                    .provider_commit(Commit {
-                        dapp: dapp_contract_account,
-                        dataset_id: user_root,
-                        status: CaptchaStatus::Disapproved,
-                        provider: provider_account,
-                        user: dapp_user_account,
-                        completed_at: 0,
-                        requested_at: 0,
-                        id: solution_id,
-                        user_signature: Vec::new(),
-                    })
-                    .unwrap();
-                let commitment = contract
-                    .captcha_solution_commitments
-                    .get(solution_id)
-                    .unwrap();
-                assert_eq!(commitment.status, CaptchaStatus::Disapproved);
-                let new_dapp_balance = contract.get_dapp_balance(dapp_contract_account).unwrap();
-                let new_provider_balance = contract.get_provider_balance(provider_account).unwrap();
-                assert_eq!(balance - Balance::from(fee), new_dapp_balance);
-                assert_eq!(balance + Balance::from(fee), new_provider_balance);
-
-                // Now make sure that the provider cannot later set the solution to approved
-                contract.provider_commit(Commit {
-                    dapp: dapp_contract_account,
-                    dataset_id: user_root,
-                    status: CaptchaStatus::Approved,
-                    provider: provider_account,
-                    user: dapp_user_account,
-                    completed_at: 0,
-                    requested_at: 0,
-                    id: solution_id,
-                    user_signature: Vec::new(),
-                });
-                let commitment = contract
-                    .captcha_solution_commitments
-                    .get(solution_id)
-                    .unwrap();
-                assert_eq!(commitment.status, CaptchaStatus::Disapproved);
-                assert_eq!(
-                    balance - Balance::from(fee),
-                    contract.get_dapp_balance(dapp_contract_account).unwrap()
-                );
-                assert_eq!(
-                    balance + Balance::from(fee),
-                    contract.get_provider_balance(provider_account).unwrap()
-                );
-            }
-
-            /// Test dapp user is human
-            #[ink::test]
-            fn test_dapp_operator_is_human_user() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-
-                // Register the provider
-                let (provider_account, url, fee) = generate_provider_data(0x2, "4242", 0);
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                contract
-                    .provider_register(url.clone(), fee, Payee::Dapp)
-                    .unwrap();
-
-                // Call from the provider account to add data and stake tokens
-                let balance = 2000000000000;
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                let root1 = str_to_hash("merkle tree1".to_string());
-                let root2 = str_to_hash("merkle tree2".to_string());
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
-                contract.provider_update(url, fee, Payee::Provider).unwrap();
-                // can only add data set after staking
-                contract.provider_set_dataset(root1, root2);
-
-                // Register the dapp
-                let dapp_caller_account = AccountId::from([0x3; 32]);
-                let dapp_contract_account = AccountId::from([0x4; 32]);
-                // Mark the the dapp account as being a contract on-chain
-                ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract_account);
-
-                // Call from the dapp account
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(dapp_caller_account);
-                // Give the dap a balance
-                let balance = 2000000000000;
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
-                contract
-                    .dapp_register(dapp_contract_account, DappPayee::Dapp)
-                    .unwrap();
-
-                //Dapp User commit
-                let dapp_user_account = AccountId::from([0x5; 32]);
-                // Call from the Dapp User Account
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(dapp_user_account);
-                let user_root = str_to_hash("user merkle tree root".to_string());
-
-                // Call from the provider account to mark the solution as disapproved
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                let solution_id = user_root;
-                contract.provider_commit(Commit {
-                    dapp: dapp_contract_account,
-                    dataset_id: user_root,
-                    status: CaptchaStatus::Disapproved,
-                    provider: provider_account,
-                    user: dapp_user_account,
-                    completed_at: 0,
-                    requested_at: 0,
-                    id: solution_id,
-                    user_signature: Vec::new(),
-                });
-                let commitment = contract
-                    .captcha_solution_commitments
-                    .get(solution_id)
-                    .unwrap();
-                assert_eq!(commitment.status, CaptchaStatus::Disapproved);
-
-                // Now make sure that the dapp user does not pass the human test
-                let result = contract.dapp_operator_is_human_user(dapp_user_account, 80);
-                assert!(!result.unwrap());
-            }
-
-            /// Test non-existent dapp account has zero balance
-            #[ink::test]
-            fn test_non_existent_dapp_account_has_zero_balance() {
-                let dapp_account = AccountId::from([0x2; 32]);
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-                contract.get_dapp_balance(dapp_account).unwrap_err();
-            }
-
-            /// Test non-existent provider account has zero balance
-            #[ink::test]
-            fn test_non_existent_provider_account_has_zero_balance() {
-                let provider_account = AccountId::from([0x2; 32]);
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-                contract.get_provider_balance(provider_account).unwrap_err();
-            }
-
-            // // Test get random provider
-            #[ink::test]
-            fn test_get_random_active_provider() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-                let provider_account = AccountId::from([0x2; 32]);
-                let url: Vec<u8> = vec![1, 2, 3];
-                let fee: u32 = 100;
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                contract.provider_register(url.clone(), fee, Payee::Dapp);
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                let balance = 20000000000000;
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
-                contract.provider_update(url, fee, Payee::Dapp);
-                let root1 = str_to_hash("merkle tree1".to_string());
-                let root2 = str_to_hash("merkle tree2".to_string());
-                contract.provider_set_dataset(root1, root2);
-                let registered_provider_account = contract.providers.get(provider_account);
-                // Register the dapp
-                let dapp_caller_account = AccountId::from([0x3; 32]);
-                let dapp_contract_account = AccountId::from([0x4; 32]);
-                // Mark the the dapp account as being a contract on-chain
-                ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract_account);
-
-                // Call from the dapp account
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(dapp_caller_account);
-                // Give the dap a balance
-                let balance = 2000000000000;
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
-                contract.dapp_register(dapp_contract_account, DappPayee::Dapp);
-                let selected_provider =
-                    contract.get_random_active_provider(provider_account, dapp_contract_account);
-                assert!(
-                    selected_provider.unwrap().provider == registered_provider_account.unwrap()
-                );
-            }
-
-            // // Test get random provider
-            #[ink::test]
-            fn test_get_random_active_provider_dapp_any() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-                let provider_account = AccountId::from([0x2; 32]);
-                let dapp_user_account = AccountId::from([0x30; 32]);
-                let url: Vec<u8> = vec![1, 2, 3];
-                let fee: u32 = 100;
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                contract.provider_register(url.clone(), fee, Payee::Provider);
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                let balance = 20000000000000;
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
-                contract.provider_update(url.clone(), fee, Payee::Provider);
-                let root1 = str_to_hash("merkle tree1".to_string());
-                let root2 = str_to_hash("merkle tree2".to_string());
-                contract.provider_set_dataset(root1, root2);
-
-                // Register the dapp
-                let dapp_caller_account = AccountId::from([0x3; 32]);
-                let dapp_contract_account = AccountId::from([0x4; 32]);
-                // Mark the the dapp account as being a contract on-chain
-                ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract_account);
-
-                // Call from the dapp account
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(dapp_caller_account);
-                // Give the dapp a balance
-                let balance = 2000000000000;
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
-                contract.dapp_register(dapp_contract_account, DappPayee::Any);
-
-                // Call from the dapp_user_account
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(dapp_user_account);
-
-                // Call as dapp user and get a random provider
-                let selected_provider =
-                    contract.get_random_active_provider(dapp_user_account, dapp_contract_account);
-                assert_eq!(selected_provider.unwrap().provider_id, provider_account);
-
-                // Switch the provider payee to Dapp
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                contract.provider_update(url, fee, Payee::Dapp);
-
-                // Call from the dapp_user_account
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(dapp_user_account);
-
-                // Call as dapp user and get a random provider. Ensure that the provider is still
-                // selected despite the payee change
-                let selected_provider =
-                    contract.get_random_active_provider(dapp_user_account, dapp_contract_account);
-                assert_eq!(selected_provider.unwrap().provider_id, provider_account);
-            }
-
-            /// Test provider can supply a dapp user commit for themselves and approve or disapprove it
-            #[ink::test]
-            fn test_provider_commit_and_approve_and_disapprove() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-
-                // Register the provider
-                let (provider_account, url, fee) = generate_provider_data(0x2, "4242", 0);
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                contract
-                    .provider_register(url.clone(), fee, Payee::Dapp)
-                    .unwrap();
-
-                // Call from the provider account to add data and stake tokens
-                let balance = 2000000000000;
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                let root1 = str_to_hash("merkle tree1".to_string());
-                let root2 = str_to_hash("merkle tree2".to_string());
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
-                contract.provider_update(url, fee, Payee::Provider);
-                // can only add data set after staking
-                contract.provider_set_dataset(root1, root2).ok();
-
-                // Register the dapp
-                let dapp_caller_account = AccountId::from([0x3; 32]);
-                let dapp_contract_account = AccountId::from([0x4; 32]);
-                // Mark the the dapp account as being a contract on-chain
-                ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract_account);
-
-                // Call from the dapp account
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(dapp_caller_account);
-                // Give the dap a balance
-                let balance = 2000000000000;
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
-                contract.dapp_register(dapp_contract_account, DappPayee::Dapp);
-
-                // Call from the provider account
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-
-                //Dapp User commit and approve
-                let dapp_user_account = AccountId::from([0x5; 32]);
-                let user_root1 = str_to_hash("user merkle tree root to approve".to_string());
-                contract.provider_commit(Commit {
-                    dapp: dapp_contract_account,
-                    dataset_id: user_root1,
-                    status: CaptchaStatus::Approved,
-                    provider: provider_account,
-                    user: dapp_user_account,
-                    completed_at: 0,
-                    requested_at: 0,
-                    id: user_root1,
-                    user_signature: Vec::new(),
-                });
-
-                // Get the commitment and make sure it is approved
-                let commitment = contract
-                    .get_captcha_solution_commitment(user_root1)
-                    .unwrap();
-                assert_eq!(commitment.status, CaptchaStatus::Approved);
-
-                //Dapp User commit and disapprove
-                let dapp_user_account = AccountId::from([0x5; 32]);
-                let user_root2 = str_to_hash("user merkle tree root to disapprove".to_string());
-                contract.provider_commit(Commit {
-                    dapp: dapp_contract_account,
-                    dataset_id: root2,
-                    status: CaptchaStatus::Disapproved,
-                    provider: provider_account,
-                    user: dapp_user_account,
-                    completed_at: 0,
-                    requested_at: 0,
-                    id: user_root2,
-                    user_signature: Vec::new(),
-                });
-
-                // Get the commitment and make sure it is disapproved
-                let commitment = contract
-                    .get_captcha_solution_commitment(user_root2)
-                    .unwrap();
-                assert_eq!(commitment.status, CaptchaStatus::Disapproved);
-            }
-
-            /// Test provider cannot supply a dapp user commit for a different Provider
-            #[ink::test]
-            fn test_provider_cannot_supply_commit_for_a_different_provider() {
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-
-                // Register the provider
-                let (provider_account, url, fee) = generate_provider_data(0x2, "4242", 0);
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                contract
-                    .provider_register(url.clone(), fee, Payee::Dapp)
-                    .unwrap();
-
-                // Call from the provider account to add data and stake tokens
-                let balance = 2000000000000;
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
-                let root1 = str_to_hash("merkle tree1".to_string());
-                let root2 = str_to_hash("merkle tree2".to_string());
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
-                contract.provider_update(url, fee, Payee::Provider);
-                // can only add data set after staking
-                contract.provider_set_dataset(root1, root2).ok();
-
-                // Register the dapp
-                let dapp_user_account = AccountId::from([0x3; 32]);
-                let dapp_contract_account = AccountId::from([0x4; 32]);
-                // Mark the the dapp account as being a contract on-chain
-                ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract_account);
-
-                // Call from the dapp_contract_account
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(dapp_contract_account);
-                // Give the dap a balance
-                let balance = 2000000000000;
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
-                contract.dapp_register(dapp_contract_account, DappPayee::Dapp);
-
-                // Register a second provider
-                let (provider_account2, url, fee) = generate_provider_data(0x5, "2424", 0);
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account2);
-                contract
-                    .provider_register(url.clone(), fee, Payee::Dapp)
-                    .unwrap();
-
-                // Call from the provider account to add data and stake tokens
-                let balance = 2000000000000;
-                let root1 = str_to_hash("merkle tree1".to_string());
-                let root2 = str_to_hash("merkle tree2".to_string());
-                ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
-                contract.provider_update(url, fee, Payee::Provider);
-                // can only add data set after staking
-                contract.provider_set_dataset(root1, root2).ok();
-
-                // Call from dapp_user_commit from provider_account2 to supply a commit for provider_account
-                // Should not be authorised
-                let dapp_user_account = AccountId::from([0x6; 32]);
-                let user_root = str_to_hash("user merkle tree root".to_string());
-            }
-
-            /// Get some operator accounts as a vector
-            fn get_operator_accounts() -> Vec<AccountId> {
-                let operator_account1 = AccountId::from([0x1; 32]);
-                let operator_account2 = AccountId::from([0x10; 32]);
-                let mut operator_accounts = vec![operator_account1, operator_account2];
-                operator_accounts
-            }
-
-            fn setup_contract() -> (AccountId, AccountId, Vec<AccountId>, Prosopo) {
-                let op1 = AccountId::from([0x1; 32]);
-                let op2 = AccountId::from([0x2; 32]);
-                let ops = vec![op1, op2];
-                // initialise the contract
-                // always set the caller to the unused account to start, avoid any mistakes with caller checks
-                set_caller(get_unused_account());
-
-                let mut contract = get_contract(0);
-                (op1, op2, ops, contract)
-            }
-
-            /// Test dapp cannot register if existing dapp in place
-            #[ink::test]
-            fn test_dapp_register_existing() {
-                let (op1, op2, ops, mut contract) = setup_contract();
-                let dapp_contract = AccountId::from([0x4; 32]);
-
-                // Mark the the dapp account as being a contract on-chain
-                ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract);
-
-                // the caller should be someone who isn't an operator
-                ink::env::test::set_caller::<ink::env::DefaultEnvironment>(AccountId::from(
-                    [0x3; 32],
-                ));
-
+                })
+                .unwrap();
+            let commitment = contract
+                .captcha_solution_commitments
+                .get(solution_id)
+                .unwrap();
+            assert_eq!(commitment.status, CaptchaStatus::Disapproved);
+            let new_dapp_balance = contract.get_dapp_balance(dapp_contract_account).unwrap();
+            let new_provider_balance = contract.get_provider_balance(provider_account).unwrap();
+            assert_eq!(balance - Balance::from(fee), new_dapp_balance);
+            assert_eq!(balance + Balance::from(fee), new_provider_balance);
+
+            // Now make sure that the provider cannot later set the solution to approved
+            contract.provider_commit(Commit {
+                dapp: dapp_contract_account,
+                dataset_id: user_root,
+                status: CaptchaStatus::Approved,
+                provider: provider_account,
+                user: dapp_user_account,
+                completed_at: 0,
+                requested_at: 0,
+                id: solution_id,
+                user_signature: Vec::new(),
+            });
+            let commitment = contract
+                .captcha_solution_commitments
+                .get(solution_id)
+                .unwrap();
+            assert_eq!(commitment.status, CaptchaStatus::Disapproved);
+            assert_eq!(
+                balance - Balance::from(fee),
+                contract.get_dapp_balance(dapp_contract_account).unwrap()
+            );
+            assert_eq!(
+                balance + Balance::from(fee),
+                contract.get_provider_balance(provider_account).unwrap()
+            );
+        }
+
+        /// Test dapp user is human
+        #[ink::test]
+        fn test_dapp_operator_is_human_user() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+
+            // Register the provider
+            let (provider_account, url, fee) = generate_provider_data(0x2, "4242", 0);
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            contract
+                .provider_register(url.clone(), fee, Payee::Dapp)
+                .unwrap();
+
+            // Call from the provider account to add data and stake tokens
+            let balance = 2000000000000;
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            let root1 = str_to_hash("merkle tree1".to_string());
+            let root2 = str_to_hash("merkle tree2".to_string());
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
+            contract.provider_update(url, fee, Payee::Provider).unwrap();
+            // can only add data set after staking
+            contract.provider_set_dataset(root1, root2);
+
+            // Register the dapp
+            let dapp_caller_account = AccountId::from([0x3; 32]);
+            let dapp_contract_account = AccountId::from([0x4; 32]);
+            // Mark the the dapp account as being a contract on-chain
+            ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract_account);
+
+            // Call from the dapp account
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(dapp_caller_account);
+            // Give the dap a balance
+            let balance = 2000000000000;
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
+            contract
+                .dapp_register(dapp_contract_account, DappPayee::Dapp)
+                .unwrap();
+
+            //Dapp User commit
+            let dapp_user_account = AccountId::from([0x5; 32]);
+            // Call from the Dapp User Account
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(dapp_user_account);
+            let user_root = str_to_hash("user merkle tree root".to_string());
+
+            // Call from the provider account to mark the solution as disapproved
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            let solution_id = user_root;
+            contract.provider_commit(Commit {
+                dapp: dapp_contract_account,
+                dataset_id: user_root,
+                status: CaptchaStatus::Disapproved,
+                provider: provider_account,
+                user: dapp_user_account,
+                completed_at: 0,
+                requested_at: 0,
+                id: solution_id,
+                user_signature: Vec::new(),
+            });
+            let commitment = contract
+                .captcha_solution_commitments
+                .get(solution_id)
+                .unwrap();
+            assert_eq!(commitment.status, CaptchaStatus::Disapproved);
+
+            // Now make sure that the dapp user does not pass the human test
+            let result = contract.dapp_operator_is_human_user(dapp_user_account, 80);
+            assert!(!result.unwrap());
+        }
+
+        /// Test non-existent dapp account has zero balance
+        #[ink::test]
+        fn test_non_existent_dapp_account_has_zero_balance() {
+            let dapp_account = AccountId::from([0x2; 32]);
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+            contract.get_dapp_balance(dapp_account).unwrap_err();
+        }
+
+        /// Test non-existent provider account has zero balance
+        #[ink::test]
+        fn test_non_existent_provider_account_has_zero_balance() {
+            let provider_account = AccountId::from([0x2; 32]);
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+            contract.get_provider_balance(provider_account).unwrap_err();
+        }
+
+        // // Test get random provider
+        #[ink::test]
+        fn test_get_random_active_provider() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+            let provider_account = AccountId::from([0x2; 32]);
+            let url: Vec<u8> = vec![1, 2, 3];
+            let fee: u32 = 100;
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            contract.provider_register(url.clone(), fee, Payee::Dapp);
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            let balance = 20000000000000;
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
+            contract.provider_update(url, fee, Payee::Dapp);
+            let root1 = str_to_hash("merkle tree1".to_string());
+            let root2 = str_to_hash("merkle tree2".to_string());
+            contract.provider_set_dataset(root1, root2);
+            let registered_provider_account = contract.providers.get(provider_account);
+            // Register the dapp
+            let dapp_caller_account = AccountId::from([0x3; 32]);
+            let dapp_contract_account = AccountId::from([0x4; 32]);
+            // Mark the the dapp account as being a contract on-chain
+            ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract_account);
+
+            // Call from the dapp account
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(dapp_caller_account);
+            // Give the dap a balance
+            let balance = 2000000000000;
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
+            contract.dapp_register(dapp_contract_account, DappPayee::Dapp);
+            let selected_provider =
+                contract.get_random_active_provider(provider_account, dapp_contract_account);
+            assert!(selected_provider.unwrap().provider == registered_provider_account.unwrap());
+        }
+
+        // // Test get random provider
+        #[ink::test]
+        fn test_get_random_active_provider_dapp_any() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+            let provider_account = AccountId::from([0x2; 32]);
+            let dapp_user_account = AccountId::from([0x30; 32]);
+            let url: Vec<u8> = vec![1, 2, 3];
+            let fee: u32 = 100;
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            contract.provider_register(url.clone(), fee, Payee::Provider);
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            let balance = 20000000000000;
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
+            contract.provider_update(url.clone(), fee, Payee::Provider);
+            let root1 = str_to_hash("merkle tree1".to_string());
+            let root2 = str_to_hash("merkle tree2".to_string());
+            contract.provider_set_dataset(root1, root2);
+
+            // Register the dapp
+            let dapp_caller_account = AccountId::from([0x3; 32]);
+            let dapp_contract_account = AccountId::from([0x4; 32]);
+            // Mark the the dapp account as being a contract on-chain
+            ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract_account);
+
+            // Call from the dapp account
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(dapp_caller_account);
+            // Give the dapp a balance
+            let balance = 2000000000000;
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
+            contract.dapp_register(dapp_contract_account, DappPayee::Any);
+
+            // Call from the dapp_user_account
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(dapp_user_account);
+
+            // Call as dapp user and get a random provider
+            let selected_provider =
+                contract.get_random_active_provider(dapp_user_account, dapp_contract_account);
+            assert_eq!(selected_provider.unwrap().provider_id, provider_account);
+
+            // Switch the provider payee to Dapp
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            contract.provider_update(url, fee, Payee::Dapp);
+
+            // Call from the dapp_user_account
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(dapp_user_account);
+
+            // Call as dapp user and get a random provider. Ensure that the provider is still
+            // selected despite the payee change
+            let selected_provider =
+                contract.get_random_active_provider(dapp_user_account, dapp_contract_account);
+            assert_eq!(selected_provider.unwrap().provider_id, provider_account);
+        }
+
+        /// Test provider can supply a dapp user commit for themselves and approve or disapprove it
+        #[ink::test]
+        fn test_provider_commit_and_approve_and_disapprove() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+
+            // Register the provider
+            let (provider_account, url, fee) = generate_provider_data(0x2, "4242", 0);
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            contract
+                .provider_register(url.clone(), fee, Payee::Dapp)
+                .unwrap();
+
+            // Call from the provider account to add data and stake tokens
+            let balance = 2000000000000;
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            let root1 = str_to_hash("merkle tree1".to_string());
+            let root2 = str_to_hash("merkle tree2".to_string());
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
+            contract.provider_update(url, fee, Payee::Provider);
+            // can only add data set after staking
+            contract.provider_set_dataset(root1, root2).ok();
+
+            // Register the dapp
+            let dapp_caller_account = AccountId::from([0x3; 32]);
+            let dapp_contract_account = AccountId::from([0x4; 32]);
+            // Mark the the dapp account as being a contract on-chain
+            ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract_account);
+
+            // Call from the dapp account
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(dapp_caller_account);
+            // Give the dap a balance
+            let balance = 2000000000000;
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
+            contract.dapp_register(dapp_contract_account, DappPayee::Dapp);
+
+            // Call from the provider account
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+
+            //Dapp User commit and approve
+            let dapp_user_account = AccountId::from([0x5; 32]);
+            let user_root1 = str_to_hash("user merkle tree root to approve".to_string());
+            contract.provider_commit(Commit {
+                dapp: dapp_contract_account,
+                dataset_id: user_root1,
+                status: CaptchaStatus::Approved,
+                provider: provider_account,
+                user: dapp_user_account,
+                completed_at: 0,
+                requested_at: 0,
+                id: user_root1,
+                user_signature: Vec::new(),
+            });
+
+            // Get the commitment and make sure it is approved
+            let commitment = contract
+                .get_captcha_solution_commitment(user_root1)
+                .unwrap();
+            assert_eq!(commitment.status, CaptchaStatus::Approved);
+
+            //Dapp User commit and disapprove
+            let dapp_user_account = AccountId::from([0x5; 32]);
+            let user_root2 = str_to_hash("user merkle tree root to disapprove".to_string());
+            contract.provider_commit(Commit {
+                dapp: dapp_contract_account,
+                dataset_id: root2,
+                status: CaptchaStatus::Disapproved,
+                provider: provider_account,
+                user: dapp_user_account,
+                completed_at: 0,
+                requested_at: 0,
+                id: user_root2,
+                user_signature: Vec::new(),
+            });
+
+            // Get the commitment and make sure it is disapproved
+            let commitment = contract
+                .get_captcha_solution_commitment(user_root2)
+                .unwrap();
+            assert_eq!(commitment.status, CaptchaStatus::Disapproved);
+        }
+
+        /// Test provider cannot supply a dapp user commit for a different Provider
+        #[ink::test]
+        fn test_provider_cannot_supply_commit_for_a_different_provider() {
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+
+            // Register the provider
+            let (provider_account, url, fee) = generate_provider_data(0x2, "4242", 0);
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            contract
+                .provider_register(url.clone(), fee, Payee::Dapp)
+                .unwrap();
+
+            // Call from the provider account to add data and stake tokens
+            let balance = 2000000000000;
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account);
+            let root1 = str_to_hash("merkle tree1".to_string());
+            let root2 = str_to_hash("merkle tree2".to_string());
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
+            contract.provider_update(url, fee, Payee::Provider);
+            // can only add data set after staking
+            contract.provider_set_dataset(root1, root2).ok();
+
+            // Register the dapp
+            let dapp_user_account = AccountId::from([0x3; 32]);
+            let dapp_contract_account = AccountId::from([0x4; 32]);
+            // Mark the the dapp account as being a contract on-chain
+            ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract_account);
+
+            // Call from the dapp_contract_account
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(dapp_contract_account);
+            // Give the dap a balance
+            let balance = 2000000000000;
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
+            contract.dapp_register(dapp_contract_account, DappPayee::Dapp);
+
+            // Register a second provider
+            let (provider_account2, url, fee) = generate_provider_data(0x5, "2424", 0);
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(provider_account2);
+            contract
+                .provider_register(url.clone(), fee, Payee::Dapp)
+                .unwrap();
+
+            // Call from the provider account to add data and stake tokens
+            let balance = 2000000000000;
+            let root1 = str_to_hash("merkle tree1".to_string());
+            let root2 = str_to_hash("merkle tree2".to_string());
+            ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(balance);
+            contract.provider_update(url, fee, Payee::Provider);
+            // can only add data set after staking
+            contract.provider_set_dataset(root1, root2).ok();
+
+            // Call from dapp_user_commit from provider_account2 to supply a commit for provider_account
+            // Should not be authorised
+            let dapp_user_account = AccountId::from([0x6; 32]);
+            let user_root = str_to_hash("user merkle tree root".to_string());
+        }
+
+        /// Get some operator accounts as a vector
+        fn get_operator_accounts() -> Vec<AccountId> {
+            let operator_account1 = AccountId::from([0x1; 32]);
+            let operator_account2 = AccountId::from([0x10; 32]);
+            let mut operator_accounts = vec![operator_account1, operator_account2];
+            operator_accounts
+        }
+
+        fn setup_contract() -> (AccountId, AccountId, Vec<AccountId>, Prosopo) {
+            let op1 = AccountId::from([0x1; 32]);
+            let op2 = AccountId::from([0x2; 32]);
+            let ops = vec![op1, op2];
+            // initialise the contract
+            // always set the caller to the unused account to start, avoid any mistakes with caller checks
+            set_caller(get_unused_account());
+
+            let mut contract = get_contract(0);
+            (op1, op2, ops, contract)
+        }
+
+        /// Test dapp cannot register if existing dapp in place
+        #[ink::test]
+        fn test_dapp_register_existing() {
+            let (op1, op2, ops, mut contract) = setup_contract();
+            let dapp_contract = AccountId::from([0x4; 32]);
+
+            // Mark the the dapp account as being a contract on-chain
+            ink::env::test::set_contract::<ink::env::DefaultEnvironment>(dapp_contract);
+
+            // the caller should be someone who isn't an operator
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(AccountId::from([0x3; 32]));
+
+            contract
+                .dapp_register(dapp_contract, DappPayee::Dapp)
+                .unwrap();
+            assert_eq!(
+                Error::DappExists,
                 contract
                     .dapp_register(dapp_contract, DappPayee::Dapp)
-                    .unwrap();
-                assert_eq!(
-                    Error::DappExists,
-                    contract
-                        .dapp_register(dapp_contract, DappPayee::Dapp)
-                        .unwrap_err()
-                );
-            }
+                    .unwrap_err()
+            );
         }
     }
 }


### PR DESCRIPTION
just removed the module wrapper around the unit tests. We had two because the outer allowed for structs, but this idea has been superseded, so putting it back to original single module