### PR TITLE
Signature parts

### DIFF
--- a/contracts/captcha/src/lib.rs
+++ b/contracts/captcha/src/lib.rs
@@ -2742,7 +2742,8 @@ pub mod captcha {
                     completed_at: 0,
                     requested_at: 0,
                     id: solution_id,
-                    user_signature: Vec::new(),
+                    user_signature_part1: [0x0; 32],
+                    user_signature_part2: [0x0; 32],
                 });
                 let commitment = contract
                     .captcha_solution_commitments
@@ -2766,7 +2767,8 @@ pub mod captcha {
                     completed_at: 0,
                     requested_at: 0,
                     id: solution_id,
-                    user_signature: Vec::new(),
+                    user_signature_part1: [0x0; 32],
+                    user_signature_part2: [0x0; 32],
                 });
                 let commitment = contract
                     .captcha_solution_commitments
@@ -2841,7 +2843,8 @@ pub mod captcha {
                     completed_at: 0,
                     requested_at: 0,
                     id: solution_id,
-                    user_signature: Vec::new(),
+                    user_signature_part1: [0x0; 32],
+                    user_signature_part2: [0x0; 32],
                 });
             }
 
@@ -2906,7 +2909,8 @@ pub mod captcha {
                         completed_at: 0,
                         requested_at: 0,
                         id: solution_id,
-                        user_signature: Vec::new(),
+                        user_signature_part1: [0x0; 32],
+                        user_signature_part2: [0x0; 32],
                     })
                     .unwrap();
                 let commitment = contract
@@ -2929,7 +2933,8 @@ pub mod captcha {
                     completed_at: 0,
                     requested_at: 0,
                     id: solution_id,
-                    user_signature: Vec::new(),
+                    user_signature_part1: [0x0; 32],
+                    user_signature_part2: [0x0; 32],
                 });
                 let commitment = contract
                     .captcha_solution_commitments
@@ -3004,7 +3009,8 @@ pub mod captcha {
                     completed_at: 0,
                     requested_at: 0,
                     id: solution_id,
-                    user_signature: Vec::new(),
+                    user_signature_part1: [0x0; 32],
+                    user_signature_part2: [0x0; 32],
                 });
                 let commitment = contract
                     .captcha_solution_commitments
@@ -3187,7 +3193,8 @@ pub mod captcha {
                     completed_at: 0,
                     requested_at: 0,
                     id: user_root1,
-                    user_signature: Vec::new(),
+                    user_signature_part1: [0x0; 32],
+                    user_signature_part2: [0x0; 32],
                 });
 
                 // Get the commitment and make sure it is approved
@@ -3208,7 +3215,8 @@ pub mod captcha {
                     completed_at: 0,
                     requested_at: 0,
                     id: user_root2,
-                    user_signature: Vec::new(),
+                    user_signature_part1: [0x0; 32],
+                    user_signature_part2: [0x0; 32],
                 });
 
                 // Get the commitment and make sure it is disapproved

--- a/contracts/captcha/src/lib.rs
+++ b/contracts/captcha/src/lib.rs
@@ -168,15 +168,15 @@ pub mod captcha {
     #[derive(PartialEq, Debug, Eq, Clone, scale::Encode, scale::Decode)]
     #[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout))]
     pub struct Commit {
-        id: Hash,                  // the commitment id
-        user: AccountId,           // the user who submitted the commitment
-        dataset_id: Hash,          // the dataset id
-        status: CaptchaStatus,     // the status of the commitment
-        dapp: AccountId,           // the dapp which the user completed the captcha on
-        provider: AccountId,       // the provider who supplied the challenge
-        requested_at: BlockNumber, // the block number at which the captcha was requested
-        completed_at: BlockNumber, // the block number at which the captcha was completed
-        user_signature_part1: [u8; 32],   // the user's signature of the commitment
+        id: Hash,                       // the commitment id
+        user: AccountId,                // the user who submitted the commitment
+        dataset_id: Hash,               // the dataset id
+        status: CaptchaStatus,          // the status of the commitment
+        dapp: AccountId,                // the dapp which the user completed the captcha on
+        provider: AccountId,            // the provider who supplied the challenge
+        requested_at: BlockNumber,      // the block number at which the captcha was requested
+        completed_at: BlockNumber,      // the block number at which the captcha was completed
+        user_signature_part1: [u8; 32], // the user's signature of the commitment
         user_signature_part2: [u8; 32],
     }
 

--- a/contracts/captcha/src/lib.rs
+++ b/contracts/captcha/src/lib.rs
@@ -176,7 +176,8 @@ pub mod captcha {
         provider: AccountId,       // the provider who supplied the challenge
         requested_at: BlockNumber, // the block number at which the captcha was requested
         completed_at: BlockNumber, // the block number at which the captcha was completed
-        user_signature: Vec<u8>,   // the user's signature of the commitment
+        user_signature_part1: [u8; 32],   // the user's signature of the commitment
+        user_signature_part2: [u8; 32],
     }
 
     /// DApps are distributed apps who want their users to be verified by Providers, either paying


### PR DESCRIPTION
Split signature into two `[u8;32]` variables instead of using `vec`. When we have access to `[u8;64]` in the next rust version, we can switch this to a single variable